### PR TITLE
Issue #9 possible solution

### DIFF
--- a/sorl/thumbnail/conf/defaults.py
+++ b/sorl/thumbnail/conf/defaults.py
@@ -63,3 +63,5 @@ THUMBNAIL_DUMMY = False
 # or height given
 THUMBNAIL_DUMMY_RATIO = 3.0 / 2
 
+# Enabled mailing to the managers about missing images
+THUMBNAIL_SEND_MISSING_IMAGE_EMAIL = False

--- a/sorl/thumbnail/engines/base.py
+++ b/sorl/thumbnail/engines/base.py
@@ -1,6 +1,9 @@
 #coding=utf-8
+from django.core.mail import mail_managers
 from sorl.thumbnail.helpers import toint
 from sorl.thumbnail.parsers import parse_crop
+from sorl.thumbnail.conf import settings
+
 
 
 class EngineBase(object):
@@ -62,6 +65,15 @@ class EngineBase(object):
     def get_image_ratio(self, image):
         x, y = self.get_image_size(image)
         return float(x) / y
+        
+        
+    def _missing_image(self, source):
+        """
+            Handles what happens in case of a missing image
+        """
+        if settings.THUMBNAIL_SEND_MISSING_IMAGE_EMAIL:
+            mail_managers('Missing image', 'The following image is missing: %s' % source.url, fail_silently=True)
+        return self.dummy_image(800, 600)
 
     #
     # Methods which engines need to implement

--- a/sorl/thumbnail/engines/pgmagick_engine.py
+++ b/sorl/thumbnail/engines/pgmagick_engine.py
@@ -12,9 +12,13 @@ except ImportError:
 
 class Engine(EngineBase):
     def get_image(self, source):
-        blob = Blob()
-        blob.update(source.read())
-        return Image(blob)
+        try:
+            blob = Blob()
+            blob.update(source.read())
+            img = Image(blob)
+        except IOError:
+            img = self._missing_image(source)
+        return img
 
     def get_image_size(self, image):
         geometry = image.size()

--- a/sorl/thumbnail/engines/pil_engine.py
+++ b/sorl/thumbnail/engines/pil_engine.py
@@ -9,8 +9,12 @@ except ImportError:
 
 class Engine(EngineBase):
     def get_image(self, source):
-        buf = StringIO(source.read())
-        return Image.open(buf)
+        try:
+            buf = StringIO(source.read())
+            img = Image.open(buf)
+        except IOError:
+            img = self._missing_image(source)
+        return img
 
     def get_image_size(self, image):
         return image.size


### PR DESCRIPTION
This might work, but yeah the error state get's cached in this case. 

But on the other hand when an image is missing you have to manually fix it anyway. You either fix it by putting the physical image back from a backup or you reupload it on the website, in which case the source image is newer then the thumbnailed version, so a new thumbnail will be generated.
