### PR TITLE
Forgot to include admin code

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -33,6 +33,7 @@ setup(
     packages=[
         'sorl',
         'sorl.thumbnail',
+        'sorl.thumbnail.admin',
         'sorl.thumbnail.conf',
         'sorl.thumbnail.engines',
         'sorl.thumbnail.kvstores',


### PR DESCRIPTION
Hey there,

In your most recent package/release you have forgotten to include the newly added `sorl.thumbnail.admin` package in `setup.py`. This patch should fix that.

Kind regards,
Mathijs

PS. You might want to consider using `find_packages()` instead as to never hit upon these kind of issues again.
