### PR TITLE
Support for pgmagick Image.orientation()

### DIFF
--- a/sorl/thumbnail/engines/pgmagick_engine.py
+++ b/sorl/thumbnail/engines/pgmagick_engine.py
@@ -27,13 +27,13 @@ class Engine(EngineBase):
         elif orientation == OrientationType.BottomLeftOrientation:
             image.flip()
         elif orientation == OrientationType.LeftTopOrientation:
-            image.flip().rotate(270.)
+            image.rotate(90.).flip()
         elif orientation == OrientationType.RightTopOrientation:
-            image.rotate(270.)
-        elif orientation == OrientationType.RightBottomOrientation:
-            image.flop().rotate(270.)
-        elif orientation == OrientationType.LeftBottomOrientation:
             image.rotate(90.)
+        elif orientation == OrientationType.RightBottomOrientation:
+            image.rotate(90.).flop()
+        elif orientation == OrientationType.LeftBottomOrientation:
+            image.rotate(270.)
 
         image.orientation(OrientationType.TopLeftOrientation)
 


### PR DESCRIPTION
I don't know if you want to put this in get_image() or elsewhere. However, you can use this code to fix orientation. Fixes #34
