### PR TITLE
Ability to use Elastic Search as your Key Value Store.

### DIFF
--- a/sorl/thumbnail/conf/defaults.py
+++ b/sorl/thumbnail/conf/defaults.py
@@ -76,5 +76,10 @@ THUMBNAIL_ELASTIC_SEARCH_SERVERS = ['localhost:9200',]
 THUMBNAIL_ELASTIC_SEARCH_INDEX = "thumbnails"
 THUMBNAIL_ELASTIC_SEARCH_DOCUMENT_TYPE = "thumbnail"
 THUMBNAIL_ELASTIC_SEARCH_MAPPING = {"thumbnail": 
-                                    {"_id": {"index": "not_analyzed", "store": "yes"}}}
+                                    {"_id": {"index": "not_analyzed", "store": "yes"},
+                                     "_all": {"enabled": False},
+                                     "_source": {"enabled": True},
+                                     "properties": {"value": {"type": "string", "index": "no", "store": "no"}},
+                                    }
+                                   }
 

--- a/sorl/thumbnail/images.py
+++ b/sorl/thumbnail/images.py
@@ -28,7 +28,10 @@ def serialize_image_file(image_file):
 
 
 def deserialize_image_file(s):
-    data = simplejson.loads(s)
+    if isinstance(s,dict):
+        data = s
+    else:
+        data = simplejson.loads(s)
     class LazyStorage(LazyObject):
         def _setup(self):
             self._wrapped = get_module_class(data['storage'])()

--- a/sorl/thumbnail/management/commands/setup_elastic_search_kvstore.py
+++ b/sorl/thumbnail/management/commands/setup_elastic_search_kvstore.py
@@ -5,4 +5,4 @@ class Command(NoArgsCommand):
 
     def handle_noargs(self, **options):
         from sorl.thumbnail.kvstores.elasticsearch_kvstore import setup_store
-        setup_store
+        setup_store()


### PR DESCRIPTION
This just lets you use an Elastic Search cluster as your Key Value Store.  It includes a management command for creating the index and a mapping for the document type.  The Index name, document type name, and mapping are all configurable through settings as well as the elastic search server list.  Includes recommended defaults for all settings.
