### PR TITLE
PND doesn't support cmyk

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@ from setuptools import setup, find_packages
 
 setup(
     name='sorl-thumbnail',
-    version='11.05.2',
+    version='11.05.3',
     description='Thumbnails for Django',
     long_description=open('README.rst').read(),
     author='Mikko Hellsing',

--- a/sorl/thumbnail/engines/pil_engine.py
+++ b/sorl/thumbnail/engines/pil_engine.py
@@ -45,6 +45,8 @@ class Engine(EngineBase):
     def _get_raw_data(self, image, format_, quality):
         ImageFile.MAXBLOCK = 1024 * 1024
         buf = StringIO()
+        if format_ == 'PNG' and image.mode != "RGB":
+          image = image.convert("RGB")
         try:
             image.save(buf, format=format_, quality=quality, optimize=1)
         except IOError:


### PR DESCRIPTION
I've added some code to convert image into RGB colorspace if we use PNG as a thumbnail format.
May be need to do the same fix for other engines.
