### PR TITLE
sorl.thumbnail.urls

### DIFF
--- a/sorl/thumbnail/urls.py
+++ b/sorl/thumbnail/urls.py
@@ -1,0 +1,1 @@
+# this is a fake file for backward compatibility


### PR DESCRIPTION
backward compatibility for apps which uses include('sorl.thumbnail.urls')
