### PR TITLE
Support for a wider array of database systems

### DIFF
--- a/sorl/thumbnail/models.py
+++ b/sorl/thumbnail/models.py
@@ -2,6 +2,6 @@ from django.db import models
 
 
 class KVStore(models.Model):
-    key = models.CharField(max_length=200, primary_key=True)
-    value = models.TextField()
+    key = models.CharField(max_length=200, primary_key=True, db_column='key_field')
+    value = models.TextField(db_column='value_field')
 


### PR DESCRIPTION
Added a `db_column` property to the key and valye fields in the KVStore model

This makes sorl-thumbnail support a wider variety of database systems, including MS SQL Server, by using a column name that does not conflict with a reserved keyword.
