### PR TITLE
Make sorl ImageField compatible with Django-based ImageField 

### DIFF
--- a/sorl/thumbnail/fields.py
+++ b/sorl/thumbnail/fields.py
@@ -9,7 +9,7 @@ from sorl.thumbnail import default
 __all__ = ('ImageField', 'ImageFormField')
 
 
-class ImageField(models.FileField):
+class ImageField(models.ImageField):
     def delete_file(self, instance, sender, **kwargs):
         """
         Adds deletion of thumbnails and key kalue store references to the


### PR DESCRIPTION
Otherwise, it breaks compatibility when the `height_field` and `width_field` keyword arguments are used.
