### PR TITLE
Fixing issue with settings

### DIFF
--- a/sorl/thumbnail/conf/__init__.py
+++ b/sorl/thumbnail/conf/__init__.py
@@ -7,4 +7,4 @@ sorl_settings = UserSettingsHolder(_settings)
 for setting in dir(defaults):
     if setting == setting.upper() and not hasattr(sorl_settings, setting):
         setattr(sorl_settings, setting, getattr(defaults, setting))
-settings = ush
+settings = sorl_settings


### PR DESCRIPTION
If DJANGO_SETTINGS_MODULE specified 'proj.config.dev.settings' and subsequently imported \* from proj.config.prod.settings and a thumbnail default setting override was provided none of the other defaults would load.
