### PR TITLE
The documentation uses an ImageField without upload_to= argument and it's

### DIFF
--- a/docs/examples.rst
+++ b/docs/examples.rst
@@ -86,7 +86,7 @@ value store and its thumbnail references and the thumbnail files when deleted::
     from sorl.thumbnail import ImageField
 
     class Item(models.Model):
-        image = ImageField()
+        image = ImageField(upload_to="images/")
 
 
 .. note:: You do not need to use the ``sorl.thumbnail.ImageField`` to use


### PR DESCRIPTION
The documentation uses an ImageField without upload_to= argument and it's causing a 'FileFields require an "upload_to" attribute' error message.
