### PR TITLE
Make sure -quality is passed to the convert engine

### DIFF
--- a/sorl/thumbnail/engines/convert_engine.py
+++ b/sorl/thumbnail/engines/convert_engine.py
@@ -33,6 +33,8 @@ class Engine(EngineBase):
             args.append('-%s' % k)
             if v is not None:
                 args.append('%s' % v)
+        args.append('-quality')
+        args.append('%s' % options['quality'])
         args.append(out)
         args = map(smart_str, args)
         p = Popen(args)


### PR DESCRIPTION
Fix an issue where the -quality parameter was not passed to the
ImageMagick convert program. The issue caused all images
converted using the default quality of 92.

Reported-by: Simon Zimmermann
Signed-off-by: Simon Zimmermann simonz05@gmail.com
