### PR TITLE
Removed quantize from pgmagick engine _colorspace()

### DIFF
--- a/sorl/thumbnail/engines/pgmagick_engine.py
+++ b/sorl/thumbnail/engines/pgmagick_engine.py
@@ -50,13 +50,10 @@ class Engine(EngineBase):
     def _colorspace(self, image, colorspace):
         if colorspace == 'RGB':
             image.type(ImageType.TrueColorMatteType)
-            image.quantizeColorSpace(ColorspaceType.RGBColorspace)
         elif colorspace == 'GRAY':
             image.type(ImageType.GrayscaleMatteType)
-            image.quantizeColorSpace(ColorspaceType.GRAYColorspace)
         else:
             return image
-        image.quantize()
         return image
 
     def _scale(self, image, width, height):


### PR DESCRIPTION
Removed quantize from _colorspace() method of pgmagick engine to fix issue with reduced colors and dithering. Thanks hhatto. Refs #52.
