### PR TITLE
This is for when using ImageMagick to create thumbnail of only the first...

### DIFF
--- a/sorl/thumbnail/engines/convert_engine.py
+++ b/sorl/thumbnail/engines/convert_engine.py
@@ -29,7 +29,7 @@ class Engine(EngineBase):
             image['options']['interlace'] = 'line'
         image['options']['quality'] = options['quality']
         args = settings.THUMBNAIL_CONVERT.split(' ')
-        args.append(image['source'])
+        args.append(image['source']+'[0]')
         for k, v in image['options'].iteritems():
             args.append('-%s' % k)
             if v is not None:


### PR DESCRIPTION
... page of an pdf.

Modified source to look like /path/filename.pdf[0] instead of /path/filename.pdf.

Doesn't seem to have negative impact on other file formats.
