### PR TITLE
Add support image post-processing

### DIFF
--- a/sorl/thumbnail/engines/convert_engine.py
+++ b/sorl/thumbnail/engines/convert_engine.py
@@ -36,8 +36,11 @@ class Engine(EngineBase):
                 args.append('%s' % v)
         args.append(out)
         args = map(smart_str, args)
-        p = Popen(args)
-        p.wait()
+        p1 = Popen(args)
+        p1.wait()
+        if options['format'] == 'JPEG':
+            p2 = Popen(['jpegoptim', '--strip-all', out])
+            p2.wait()
         with open(out, 'r') as fp:
             thumbnail.write(fp.read())
         os.close(handle)


### PR DESCRIPTION
This is a feature/discussion request to see if it could be
possible to add support for post-processing of thumbnails.
The feature I'm after is the ability to run thumbnails
through an additional image compressor after the initial
scaling of the thumbnail. The process of stripping images
off comments, exif, iptc markers and so forth can further
reduce the image size with no effect on image quality
(lossless compression).

Google recommends the use of jpegtran, jpegoptim, OptiPNG or
PNGOUT in their page speed docs [1](http://code.google.com/speed/page-speed/docs/payload.html#CompressImages).

I've added a naive two-line commit which will compress a
jpeg formatted image with the jpegoptim image program, if
you use the imagemagick engine (yes, i said it was naive).
This is just to get an idea of what I'm after, but I think
the more obvious solution would be to implement this in a
modular fasion.
1. Do you think this feature has a place in the sorl
   library?
2. Where and how should it be implemented?
