### PR TITLE
Minor sphinx warnings in documentation source

### DIFF
--- a/docs/management.rst
+++ b/docs/management.rst
@@ -22,7 +22,7 @@ thumbnail clear
 ``python manage.py thumbnail clear``
 
 This totally empties the Key Value Store from all keys that start with the
-:ref:`THUMBNAIL_KEY_PREFIX`. It does not delete any files. It is generally safe to
+:ref:``THUMBNAIL_KEY_PREFIX``. It does not delete any files. It is generally safe to
 run this if you do not reference the generated thumbnails by name somewhere
 else in your code. The Key Value store will update when you hit the template
 tags, and if the thumbnails still exist they will be used and not overwritten.

--- a/docs/reference/settings.rst
+++ b/docs/reference/settings.rst
@@ -119,7 +119,7 @@ Only applicable for the convert Engine.
 
 
 ``THUMBNAIL_IDENTIFY``
-=====================
+======================
 
 - Default ``'identify'``
 


### PR DESCRIPTION
Just a minor cosmetic fix for two warnings emitted by sphinx on building the documentation:

docs/reference/settings.rst:122: WARNING: Title underline too short.
docs/reference/settings.rst:122: WARNING: Title underline too short.
docs/management.rst:24: WARNING: undefined label: thumbnail_key_prefix (if the link has no caption the label must precede a section header)
