### PR TITLE
Thumbnail tag fails with ValueError for some images.

### DIFF
--- a/sorl/thumbnail/engines/convert_engine.py
+++ b/sorl/thumbnail/engines/convert_engine.py
@@ -92,24 +92,27 @@ class Engine(EngineBase):
             p.wait()
             result = p.stdout.read().strip()
             if result:
-                result = int(result)
-                options = image['options']
-                if result == 2:
-                    options['flop'] = None
-                elif result == 3:
-                    options['rotate'] = '180'
-                elif result == 4:
-                    options['flip'] = None
-                elif result == 5:
-                    options['rotate'] = '90'
-                    options['flop'] = None
-                elif result == 6:
-                    options['rotate'] = '90'
-                elif result == 7:
-                    options['rotate'] = '-90'
-                    options['flop'] = None
-                elif result == 8:
-                    options['rotate'] = '-90'
+                try:
+                    result = int(result)
+                    options = image['options']
+                    if result == 2:
+                        options['flop'] = None
+                    elif result == 3:
+                        options['rotate'] = '180'
+                    elif result == 4:
+                        options['flip'] = None
+                    elif result == 5:
+                        options['rotate'] = '90'
+                        options['flop'] = None
+                    elif result == 6:
+                        options['rotate'] = '90'
+                    elif result == 7:
+                        options['rotate'] = '-90'
+                        options['flop'] = None
+                    elif result == 8:
+                        options['rotate'] = '-90'
+                except ValueError:
+                    pass
         else:
             # ImageMagick also corrects the orientation exif data for
             # destination


### PR DESCRIPTION
I've got the following trace:

ERROR Thumbnail tag failed:
 [...skipped...]
 File "/usr/local/lib/python2.7/dist-packages/sorl_thumbnail-11.12-py2.7.egg/sorl/thumbnail/engines/convert_engine.py", line 95, in _orientation
 result = int(result)
 ValueError: invalid literal for int() with base 10: 'unknown'

I guess sometimes 'unknown' may appear in the result variable (line 95 of convert_engine.py) instead of integer value of rotation angle.

This change to seems to fix the problem
