### PR TITLE
Timeout setting

### DIFF
--- a/sorl/thumbnail/conf/defaults.py
+++ b/sorl/thumbnail/conf/defaults.py
@@ -81,3 +81,6 @@ THUMBNAIL_DUMMY_SOURCE = 'http://dummyimage.com/%(width)sx%(height)s'
 # or height given
 THUMBNAIL_DUMMY_RATIO = 1.5
 
+# Timeout, in seconds, to use when retrieving images with urllib2
+THUMBNAIL_URL_TIMEOUT = None
+

--- a/sorl/thumbnail/images.py
+++ b/sorl/thumbnail/images.py
@@ -166,7 +166,7 @@ class DummyImageFile(BaseImageFile):
 
 class UrlStorage(Storage):
     def open(self, name):
-        return urllib2.urlopen(name)
+        return urllib2.urlopen(name, None, settings.THUMBNAIL_URL_TIMEOUT)
 
     def exists(self, name):
         try:


### PR DESCRIPTION
Added a timeout setting to use with urllib2 when retrieving an image with a URL. Without the timeout setting, urllib2 will wait indefinitely for a response.
