### PR TITLE
thumbnail.exists() is too slow when using S3 as a backend storage

### DIFF
--- a/sorl/thumbnail/base.py
+++ b/sorl/thumbnail/base.py
@@ -50,9 +50,11 @@ class ThumbnailBackend(object):
         cached = default.kvstore.get(thumbnail)
         if cached:
             return cached
-        if not thumbnail.exists():
+        else:
             # We have to check exists() because the Storage backend does not
             # overwrite in some implementations.
+			# exists() is extremely slow when using S3boto as a backend, 
+			# so I've make the assumption that if the thumbnail is not cached, it doesn't exist
             source_image = default.engine.get_image(source)
             # We might as well set the size since we have the image in memory
             size = default.engine.get_image_size(source_image)


### PR DESCRIPTION
clearly, it's more a django-storages issue than a sorl issue, but in my case, when using S3 as a backend, it took about 60 secons to run thumbnail.exists() so I've removed the check and made the assumption that if the thumbnail does not exist in the cache it does not exist on the disk either. Now it runs under 1 second.
