### PR TITLE
image._getexif() can raise IndexError for some images

### DIFF
--- a/sorl/thumbnail/engines/pil_engine.py
+++ b/sorl/thumbnail/engines/pil_engine.py
@@ -27,7 +27,7 @@ class Engine(EngineBase):
     def _orientation(self, image):
         try:
             exif = image._getexif()
-        except (IndexError, AttributeError):
+        except (IndexError, AttributeError, KeyError):
             exif = None
         if exif:
             orientation = exif.get(0x0112)


### PR DESCRIPTION
I think sorl could fail silently in that case
