### PR TITLE
Remove references to django < 1.2.5 behaviour in model examples

### DIFF
--- a/docs/examples.rst
+++ b/docs/examples.rst
@@ -91,10 +91,8 @@ value store and its thumbnail references and the thumbnail files when deleted::
 
 .. note:: You do not need to use the ``sorl.thumbnail.ImageField`` to use
     ``sorl.thumbnail``. The standard ``django.db.models.ImageField`` is fine
-    except that it does not know how to delete itself from the Key Value Store
-    or its thumbnails if you delete it. Also using the
-    ``sorl.thumbnail.ImageField`` lets you plugin the nice admin addition
-    explained in the next section.
+    except that using the ``sorl.thumbnail.ImageField`` lets you plugin the
+    nice admin addition explained in the next section.
 
 
 Another example on how to use ``sorl.thumbnail.ImageField`` in your existing


### PR DESCRIPTION
Remove references about functionalities provided by
models.FileField delete_file method.

Fix #95
