### PR TITLE
clear raise ResponseError when no key in redis_kvstore

### DIFF
--- a/sorl/thumbnail/kvstores/redis_kvstore.py
+++ b/sorl/thumbnail/kvstores/redis_kvstore.py
@@ -27,3 +27,6 @@ class KVStore(KVStoreBase):
         pattern = prefix + '*'
         return self.connection.keys(pattern=pattern)
 
+    def clear(self):
+        return self.connection.flushdb()
+


### PR DESCRIPTION
I call 'default.kvstore.clear()' when setup a testcase. However,the base clear will raise a ResponseError because no key in db, use flushdb instead with a higher perfomance.
