### PR TITLE
Need to also catch IOError when checking for exif data

### DIFF
--- a/sorl/thumbnail/engines/pil_engine.py
+++ b/sorl/thumbnail/engines/pil_engine.py
@@ -27,7 +27,7 @@ class Engine(EngineBase):
     def _orientation(self, image):
         try:
             exif = image._getexif()
-        except (AttributeError, KeyError, IndexError):
+        except (AttributeError, KeyError, IndexError, IOError):
             exif = None
         if exif:
             orientation = exif.get(0x0112)


### PR DESCRIPTION
``` python
>>> get_thumbnail(p.photo, '100x100')
Traceback (most recent call last):
  File "<console>", line 1, in <module>
  File "/home/ubuntu/virtualenvs/myproj/local/lib/python2.7/site-packages/sorl/thumbnail/shortcuts.py", line 8, in get_thumbnail
    return default.backend.get_thumbnail(file_, geometry_string, **options)
  File "/home/ubuntu/virtualenvs/myproj/local/lib/python2.7/site-packages/sorl/thumbnail/base.py", line 61, in get_thumbnail
    thumbnail)
  File "/home/ubuntu/virtualenvs/myproj/local/lib/python2.7/site-packages/sorl/thumbnail/base.py", line 86, in _create_thumbnail
    image = default.engine.create(source_image, geometry, options)
  File "/home/ubuntu/virtualenvs/myproj/local/lib/python2.7/site-packages/sorl/thumbnail/engines/base.py", line 15, in create
    image = self.orientation(image, geometry, options)
  File "/home/ubuntu/virtualenvs/myproj/local/lib/python2.7/site-packages/sorl/thumbnail/engines/base.py", line 26, in orientation
    return self._orientation(image)
  File "/home/ubuntu/virtualenvs/myproj/local/lib/python2.7/site-packages/sorl/thumbnail/engines/pil_engine.py", line 29, in _orientation
    exif = image._getexif()
  File "/home/ubuntu/virtualenvs/myproj/local/lib/python2.7/site-packages/PIL/JpegImagePlugin.py", line 391, in _getexif
    info.load(file)
  File "/home/ubuntu/virtualenvs/myproj/local/lib/python2.7/site-packages/PIL/TiffImagePlugin.py", line 382, in load
    raise IOError, "not enough data"
```
