### PR TITLE
Adding support on the low level API to DummyImages

### DIFF
--- a/sorl/thumbnail/templatetags/thumbnail.py
+++ b/sorl/thumbnail/templatetags/thumbnail.py
@@ -90,7 +90,7 @@ class ThumbnailNode(ThumbnailNodeBase):
                 options.update(value)
             else:
                 options[key] = value
-        if settings.get('THUMBNAIL_DUMMY', False):
+        if settings.THUMBNAIL_DUMMY:
             thumbnail = DummyImageFile(geometry)
         elif file_:
             thumbnail = default.backend.get_thumbnail(


### PR DESCRIPTION
The Dummy Images activated with the THUMBNAIL_DUMMY setting now work with the low level API.
