### PR TITLE
Normalizing UrlStorage url to prevent HTTP Error 505.

### DIFF
--- a/sorl/thumbnail/images.py
+++ b/sorl/thumbnail/images.py
@@ -173,7 +173,8 @@ class UrlStorage(Storage):
             s = s.encode(charset, 'replace')
         scheme, netloc, path, qs, anchor = urlparse.urlsplit(s)
         # Encode to utf8 to prevent urllib KeyError
-        path = path.encode('utf8')
+        if isinstance(path, unicode):
+            path = path.encode(charset, 'replace')
         path = urllib.quote(path, '/%')
         qs = urllib.quote_plus(qs, ':&%=')
         return urlparse.urlunsplit((scheme, netloc, path, qs, anchor))


### PR DESCRIPTION
Added url sanitation to prevent error "HTTP Error 505: HTTP Version Not Supported".
