### PR TITLE
fix: empty list of keys in clear method in management command "clear"

### DIFF
--- a/sorl/thumbnail/kvstores/base.py
+++ b/sorl/thumbnail/kvstores/base.py
@@ -114,7 +114,8 @@ class KVStoreBase(object):
         want to use the ``cleanup`` method instead.
         """
         all_keys = self._find_keys_raw(settings.THUMBNAIL_KEY_PREFIX)
-        self._delete_raw(*all_keys)
+        if all_keys:
+            self._delete_raw(*all_keys)
 
     def _get(self, key, identity='image'):
         """


### PR DESCRIPTION
./manage.py thumbnail clear
If the list of keys is empty, it throws exception "redis.exceptions.ResponseError: ERR wrong number of arguments for 'del' command" so I fixed this bug.
