### PR TITLE
Added option to get redis KV store from redis url

### DIFF
--- a/sorl/thumbnail/kvstores/redis_kvstore.py
+++ b/sorl/thumbnail/kvstores/redis_kvstore.py
@@ -1,4 +1,4 @@
-from redis import Redis
+import redis
 from sorl.thumbnail.kvstores.base import KVStoreBase
 from sorl.thumbnail.conf import settings
 
@@ -6,12 +6,15 @@ from sorl.thumbnail.conf import settings
 class KVStore(KVStoreBase):
     def __init__(self, *args, **kwargs):
         super(KVStore, self).__init__(*args, **kwargs)
-        self.connection = Redis(
-            host=settings.THUMBNAIL_REDIS_HOST,
-            port=settings.THUMBNAIL_REDIS_PORT,
-            db=settings.THUMBNAIL_REDIS_DB,
-            password=settings.THUMBNAIL_REDIS_PASSWORD,
-            unix_socket_path=settings.THUMBNAIL_REDIS_UNIX_SOCKET_PATH,
+        if settings.THUMBNAIL_REDIS_URL:
+            self.connection = redis.from_url(settings.THUMBNAIL_REDIS_URL)
+        else:
+           self.connection = redis.Redis(
+                host=settings.THUMBNAIL_REDIS_HOST,
+                port=settings.THUMBNAIL_REDIS_PORT,
+                db=settings.THUMBNAIL_REDIS_DB,
+                password=settings.THUMBNAIL_REDIS_PASSWORD,
+                unix_socket_path=settings.THUMBNAIL_REDIS_UNIX_SOCKET_PATH,
             )
 
     def _get_raw(self, key):


### PR DESCRIPTION
Used in Redis To Go in Heroku
https://devcenter.heroku.com/articles/redistogo#using-from-python
