### PR TITLE
explain that you need to use sorl's ImageField for AdminImageMixin

### DIFF
--- a/docs/examples.rst
+++ b/docs/examples.rst
@@ -111,7 +111,7 @@ project with only small code changes::
 
 Admin examples
 ==============
-Recommended usage using ``sorl.thumbnail.admin.AdminImageMixin``::
+Recommended usage using ``sorl.thumbnail.admin.AdminImageMixin`` (note that this requires use of ``sorl.thumbnail.ImageField`` in your models as explained above)::
 
     # myapp/admin.py
     from django.contrib import admin


### PR DESCRIPTION
If you are just looking through the docs, and end up at http://sorl-thumbnail.readthedocs.org/en/latest/examples.html#admin-examples, you'll never see the section above explaining the required ImageField for models, and I and others on StackOverflow have run into this. Here's a simple change that makes it clear.
