### PR TITLE
Recommend Pillow instead of PIL

### DIFF
--- a/docs/requirements.rst
+++ b/docs/requirements.rst
@@ -63,7 +63,7 @@ Ubuntu 10.04 package installation::
 
 Installing `Python Imaging Library`_ using pip::
 
-    pip install PIL
+    pip install Pillow
 
 Watch the output for messages on what support got compiled in, you at least
 want to see the following::


### PR DESCRIPTION
PIL is unmaintained, doesn't support setuptools properly, and doesn't build correctly on modern (multi-arch-enabled) Ubuntu systems.

Pillow is a friendly fork of PIL that's actively maintained (on GitHub) and fixes all of those problems.
