### PR TITLE
Improved error logging in templates.

### DIFF
--- a/sorl/thumbnail/templatetags/thumbnail.py
+++ b/sorl/thumbnail/templatetags/thumbnail.py
@@ -52,7 +52,26 @@ class ThumbnailNodeBase(Node):
         except Exception:
             if settings.THUMBNAIL_DEBUG:
                 raise
-            logger.error('Thumbnail tag failed:', exc_info=sys.exc_info())
+
+            try:
+                error_message_template = (
+                    "Thumbnail tag failed "
+                    "in template {template_name}, error at: "
+                    "{tag_text}"
+                )
+
+                template_origin, (position_start, position_end) = self.source
+                template_text = template_origin.reload()
+                tag_text = template_text[position_start:position_end]
+
+                error_message = error_message_template.format(
+                    template_name=template_origin.name,
+                    tag_text=tag_text,
+                )
+            except Exception:
+                error_message = 'Thumbnail tag failed:'
+
+            logger.exception(error_message)
             return self.nodelist_empty.render(context)
 
     def _render(self, context):


### PR DESCRIPTION
In sentry looks like:

```
Thumbnail tag failed in template /.../apps/companies/templates/companies/company_layout.html, error at: {% thumbnail company.logo "153x45" as im %}

Stacktrace (most recent call last):

  File "sorl/thumbnail/templatetags/thumbnail.py", line 45, in render
    return self._render(context)
  File "sorl/thumbnail/templatetags/thumbnail.py", line 116, in _render
    file_, geometry, **options
  File "sorl/thumbnail/base.py", line 58, in get_thumbnail
    size = default.engine.get_image_size(source_image)
  File "sorl/thumbnail/engines/convert_engine.py", line 65, in get_image_size
    image['size'] = int(m.group('x')), int(m.group('y'))
```
