### PR TITLE
Added support for specifying cache configuration

### DIFF
--- a/docs/reference/settings.rst
+++ b/docs/reference/settings.rst
@@ -188,6 +188,15 @@ maximum or ``None`` if your caching backend can handle that as infinite.
 Only applicable for the Cached DB Key Value Store.
 
 
+``THUMBNAIL_CACHE``
+===================
+
+- Default: ``'default'``
+
+Cache configuration for Cached DB Key Value Store. Defaults to the ``'default'`` cache
+but some applications might have multiple cache clusters.
+
+
 ``THUMBNAIL_KEY_PREFIX``
 ========================
 

--- a/sorl/thumbnail/conf/defaults.py
+++ b/sorl/thumbnail/conf/defaults.py
@@ -40,6 +40,9 @@ THUMBNAIL_REDIS_UNIX_SOCKET_PATH = None
 # maximum or ``0`` if your caching backend can handle that as infinate.
 THUMBNAIL_CACHE_TIMEOUT = 3600 * 24 * 365 * 10 # 10 years
 
+# The cache configuration to use for storing thumbnail data
+THUMBNAIL_CACHE = 'default'
+
 # Key prefix used by the key value store
 THUMBNAIL_KEY_PREFIX = 'sorl-thumbnail'
 


### PR DESCRIPTION
ref #176

Added a new setting THUMBNAIL_CACHE which defaults to 'default', but can be used to specify which cache configuration to use. This might be useful if running multiple cache clusters.

Signed-off-by: Rolf Håvard Blindheim rolf@moota.com
