### PR TITLE
remove usage of deprecated generic simple views

### DIFF
--- a/tests/thumbnail_tests/urls.py
+++ b/tests/thumbnail_tests/urls.py
@@ -1,4 +1,4 @@
-from django.conf.urls import *
+from django.conf.urls import patterns
 from django.conf import settings
 
 
@@ -6,6 +6,5 @@ urlpatterns = patterns(
     '',
     (r'^media/(?P<path>.+)$', 'django.views.static.serve',
      {'document_root': settings.MEDIA_ROOT, 'show_indexes': True}),
-    (r'^(.*\.html)$', 'django.views.generic.simple.direct_to_template'),
+    (r'^(.*\.html)$', 'thumbnail_tests.views.direct_to_template'),
 )
-

--- a/tests/thumbnail_tests/views.py
+++ b/tests/thumbnail_tests/views.py
@@ -1,0 +1,8 @@
+from django.template import loader, RequestContext
+from django.http import HttpResponse
+
+
+def direct_to_template(request, template, mimetype=None, **kwargs):
+    c = RequestContext(request, {})
+    t = loader.get_template(template)
+    return HttpResponse(t.render(c), mimetype=mimetype)


### PR DESCRIPTION
Implements our own direct_to_template in the test app. It is
really simple and partly based on what was in the django code
base before.
