### PR TITLE
Add text filters

### DIFF
--- a/docs/examples.rst
+++ b/docs/examples.rst
@@ -74,6 +74,13 @@ Setting format and using the is_portrait filter::
         </div>
     {% endif %}
 
+Using HTML filter::
+
+    {{ text|html_thumbnails }}
+
+Using markdown filter::
+
+    {{ text|markdown_thumbnails }}
 
 .. highlight:: python
 

--- a/docs/reference/settings.rst
+++ b/docs/reference/settings.rst
@@ -283,3 +283,10 @@ This value sets an image ratio to all thumbnails that are not defined by width
 **and** height since we cannot determine from the file input (since we don't
 have that).
 
+``THUMBNAIL_FILTER_WIDTH``
+=========================
+
+- Default: ``500``
+
+This value sets the width of thumbnails inserted when running filters one texts
+that regex replaces references to images with thumbnails.

--- a/sorl/thumbnail/conf/defaults.py
+++ b/sorl/thumbnail/conf/defaults.py
@@ -93,3 +93,6 @@ THUMBNAIL_URL_TIMEOUT = None
 
 # Temporarily Increase the PIL MAX
 THUMBNAIL_PIL_MAXBLOCK_FALLBACK = 2 ** 24
+
+# Default width when using filters for texts
+THUMBNAIL_FILTER_WIDTH = 500

--- a/tests/thumbnail_tests/templates/htmlfilter.html
+++ b/tests/thumbnail_tests/templates/htmlfilter.html
@@ -1,0 +1,4 @@
+{% load thumbnail %}
+{% autoescape off %}
+  {{ text|html_thumbnails }}
+{% endautoescape %}

--- a/tests/thumbnail_tests/templates/markdownfilter.html
+++ b/tests/thumbnail_tests/templates/markdownfilter.html
@@ -1,0 +1,2 @@
+{% load thumbnail %}
+{{ text|markdown_thumbnails }}

--- a/tests/thumbnail_tests/tests.py
+++ b/tests/thumbnail_tests/tests.py
@@ -276,6 +276,20 @@ class SimpleTestCase(SimpleTestCaseBase):
         im = self.backend.get_thumbnail(image, '32x32', crop='center')
         self.assertEqual('<img src="%s">' % im.url, val)
 
+    def test_html_filter(self):
+        text = '<img alt="A image!" src="http://dummyimage.com/800x800" />'
+        val = render_to_string('htmlfilter.html', {
+            'text': text,
+        }).strip()
+        self.assertEqual('<img alt="A image!" src="/media/test/cache/df/d5/dfd560ae0c3a15a28b73306f34d1f6e0.jpg" />', val)
+
+    def test_markdown_filter(self):
+        text = '![A image!](http://dummyimage.com/800x800)'
+        val = render_to_string('markdownfilter.html', {
+            'text': text,
+        }).strip()
+        self.assertEqual('![A image!](/media/test/cache/df/d5/dfd560ae0c3a15a28b73306f34d1f6e0.jpg)', val)
+
 
 class TemplateTestCaseA(SimpleTestCaseBase):
     def testModel(self):
@@ -586,4 +600,3 @@ class TestInputCase(unittest.TestCase):
 
     def tearDown(self):
         shutil.rmtree(settings.MEDIA_ROOT)
-


### PR DESCRIPTION
Add two filters: markdown_thumbnails, html_thumbnails. Those filters use
regex to replace images with thumbnails. The width of the thumbnails is
set to THUMBNAIL_FILTER_WIDTH which is by default 500.
#### Log from the test run:

```
Running tests for 'settings.pil'
Creating test database for alias 'default'...
..
----------------------------------------------------------------------
Ran 2 tests in 0.521s

OK
Destroying test database for alias 'default'...
```

I commented out the other tests while running the test suite since they some of them stall.
