### PR TITLE
Python 3 style print()

### DIFF
--- a/sorl/thumbnail/management/commands/thumbnail.py
+++ b/sorl/thumbnail/management/commands/thumbnail.py
@@ -14,7 +14,7 @@ class Command(BaseCommand):
         verbosity = int(options.get('verbosity'))
 
         if not labels:
-            print self.print_help('thumbnail', '')
+            print(self.print_help('thumbnail', ''))
             sys.exit(1)
 
         if len(labels) != 1:


### PR DESCRIPTION
For what I'm using sorl-thumbnail for, this appears to be the only thing stopping it working with python 3
