### PR TITLE
Fix MAXBLOCK hackery in PIL engine

### DIFF
--- a/sorl/thumbnail/engines/pil_engine.py
+++ b/sorl/thumbnail/engines/pil_engine.py
@@ -120,7 +120,8 @@ class Engine(EngineBase):
         return im
 
     def _get_raw_data(self, image, format_, quality, image_info=None, progressive=False):
-        ImageFile.MAXBLOCK = image.size[0] * image.size[1]
+        # Increase (but never decrease) PIL buffer size
+        ImageFile.MAXBLOCK = max(ImageFile.MAXBLOCK, image.size[0] * image.size[1])
         bf = BufferIO()
 
         params = {
@@ -135,18 +136,10 @@ class Engine(EngineBase):
             params['progressive'] = True
         try:
             image.save(bf, **params)
-        except IOError:
-            maxblock = ImageFile.MAXBLOCK
-
-            try:
-                # Temporary encrease ImageFile MAXBLOCK
-                ImageFile.MAXBLOCK = image.size[0] * image.size[1]
-                image.save(bf, **params)
-            except IOError:
-                params.pop('optimize')
-                image.save(bf, **params)
-            finally:
-                ImageFile.MAXBLOCK = maxblock
+        except (IOError, OSError):
+            # Try without optimization.
+            params.pop('optimize')
+            image.save(bf, **params)
 
         raw_data = bf.getvalue()
         bf.close()


### PR DESCRIPTION
- Make sure we never set the buffer size lower than default.
- Remove MAXBLOCK fiddlery (we already set MAXBLOCK a few lines above)
- 'image.save()' may also raise an OSError, so catch that too.
