### PR TITLE
Fix processing of redis keys in clear & cleanup (python 3)

### DIFF
--- a/sorl/thumbnail/kvstores/base.py
+++ b/sorl/thumbnail/kvstores/base.py
@@ -15,7 +15,7 @@ def del_prefix(key):
     """
     Removes prefixes from the key
     """
-    return ('%s' % key).split('||')[-1]
+    return key.split('||')[-1]
 
 
 class KVStoreBase(object):

--- a/sorl/thumbnail/kvstores/redis_kvstore.py
+++ b/sorl/thumbnail/kvstores/redis_kvstore.py
@@ -25,5 +25,6 @@ class KVStore(KVStoreBase):
 
     def _find_keys_raw(self, prefix):
         pattern = prefix + '*'
-        return self.connection.keys(pattern=pattern)
+        return list(map(lambda key: key.decode('utf-8'),
+                        self.connection.keys(pattern=pattern)))
 


### PR DESCRIPTION
Redis keys are bytes in PY3, not str like in python 2.
Thumbnail keys are strictly ascii, so we can decode them no problem.
