### PR TITLE
Fix image orientation for PIL engine

### DIFF
--- a/sorl/thumbnail/engines/pil_engine.py
+++ b/sorl/thumbnail/engines/pil_engine.py
@@ -140,6 +140,8 @@ class Engine(EngineBase):
         if format_ == 'JPEG' and progressive:
             params['progressive'] = True
         try:
+            # Do not save unnecessary exif data for smaller thumbnail size
+            params.pop('exif', {})
             image.save(bf, **params)
         except (IOError, OSError):
             # Try without optimization.

--- a/tests/thumbnail_tests/tests.py
+++ b/tests/thumbnail_tests/tests.py
@@ -412,7 +412,6 @@ class TemplateTestCaseA(SimpleTestCaseBase):
         m = re.search('Interlace: None', str(p.stdout.read()))
         self.assertEqual(bool(m), True)
 
-    @skip('stall')
     def test_orientation(self):
         data_dir = pjoin(settings.MEDIA_ROOT, 'data')
         shutil.copytree(settings.DATA_ROOT, data_dir)


### PR DESCRIPTION
PIL lib ignored exif, when saving images.
Pillow lib has this behavior fixed, keeping exif is optional.
More info: https://github.com/python-imaging/Pillow/issues/183

After upgrade to Pillow, there was a regression, because sorl started
to save exif data while manually rotating images according exif.
It resulted in wrong thumbnail orientation.

This is now fixed by removing exif on save.
