### PR TITLE
Don't call LazyObject._setup() unconditionally; can be destructive.

### DIFF
--- a/sorl/thumbnail/images.py
+++ b/sorl/thumbnail/images.py
@@ -2,7 +2,7 @@ import re
 
 from django.core.files.base import File, ContentFile
 from django.core.files.storage import Storage, default_storage
-from django.utils.functional import LazyObject
+from django.utils.functional import LazyObject, empty
 
 from sorl.thumbnail import default
 from sorl.thumbnail.conf import settings
@@ -143,7 +143,8 @@ class ImageFile(BaseImageFile):
         if isinstance(self.storage, LazyObject):
             # if storage is wrapped in a lazy object we need to get the real
             # thing.
-            self.storage._setup()
+            if self.storage._wrapped is empty:
+                self.storage._setup()
             cls = self.storage._wrapped.__class__
         else:
             cls = self.storage.__class__


### PR DESCRIPTION
`ImageFile.serialize_storage()` currently calls `._setup()` unconditionally on any storage it encounters that is a `LazyObject` instance. For the case of Django's `DefaultStorage` class (which is a `LazyObject`), this call to `_setup()` is destructive; it instantiates a new instance of the underlying storage class, replacing the previous one, if any. This is probably fine for many common storage classes which are not stateful, but I use [django-inmemorystorage](https://github.com/codysoyland/django-inmemorystorage) in tests, and it maintains a "filesystem" in memory for the duration of the test run. This call to `_setup()` effectively wipes out that in-memory filesystem by instantiating a new instance of the storage class. It took me quite a while to track down the cause of this.

It would be better to follow the pattern of `LazyObject` itself, and only call `setup()` if `._wrapped is empty`. This will never destructively replace an existing wrapped instance with a new one. This pull request implements that change.
