### PR TITLE
Fix documentation markup

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,8 +1,9 @@
+=========
 Changelog
 =========
 
 12.0 (TBA)
-~~~~~~~~~~
+==========
 
 * [Feature] #145 Python 3 support
 * [Feature] #165 Django 1.5-1.6 support

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -138,7 +138,7 @@ html_theme_path = ['_theme']
 # Add any paths that contain custom static files (such as style sheets) here,
 # relative to this directory. They are copied after the builtin static files,
 # so a file named "default.css" will overwrite the builtin "default.css".
-html_static_path = ['_static']
+# html_static_path = ['_static']
 
 # If not '', a 'Last updated on:' timestamp is inserted at every page bottom,
 # using the given strftime format.

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -16,6 +16,7 @@ Contents:
    operation
    reference/index
    contributing
+   news
 
 Indices and tables
 ==================

--- a/docs/news.rst
+++ b/docs/news.rst
@@ -26,7 +26,4 @@ for sorl-thumbnail is very low. If you are interested in taking over this
 project please send an email to mikko@aino.se explaing why you are the perfect
 fit for owning this project.
 
-Changelog
-=========
-
-.. include:: ../CHANGES.txt
+.. include:: ../CHANGES.rst

--- a/docs/reference/settings.rst
+++ b/docs/reference/settings.rst
@@ -301,7 +301,7 @@ This value sets an image ratio to all thumbnails that are not defined by width
 have that).
 
 ``THUMBNAIL_ALTERNATIVE_RESOLUTIONS``
-====================================
+=====================================
 
 - Default: ``[]``
 - Example: ``[1.5, 2]``
@@ -311,7 +311,7 @@ for every thumbnail. Resolution multiplicators, e.g. value 2 means for every thu
 of regular size x\*y, additional thumbnail of 2x\*2y size is created.
 
 ``THUMBNAIL_FILTER_WIDTH``
-=========================
+==========================
 
 - Default: ``500``
 


### PR DESCRIPTION
This should probably fix readthedocs build.
- add proper link to changelog in news (error)
- list news in index (warning)
- comment out unused html_static_path (warning)
- fix underlines in settings.rst (warning)
