### PR TITLE
Fix crash in logging when filename contains non-ascii characters.

### DIFF
--- a/sorl/thumbnail/base.py
+++ b/sorl/thumbnail/base.py
@@ -2,7 +2,7 @@ import logging
 
 import os
 import re
-from sorl.thumbnail.compat import string_type
+from sorl.thumbnail.compat import string_type, text_type
 from sorl.thumbnail.conf import settings, defaults as default_settings
 from sorl.thumbnail.helpers import tokey, serialize
 from sorl.thumbnail.images import ImageFile, DummyImageFile
@@ -63,7 +63,7 @@ class ThumbnailBackend(object):
         options given. First it will try to get it from the key value store,
         secondly it will create it.
         """
-        logger.debug('Getting thumbnail for file [%s] at [%s]', file_,
+        logger.debug(text_type('Getting thumbnail for file [%s] at [%s]'), file_,
                      geometry_string)
         if file_:
             source = ImageFile(file_)
@@ -105,7 +105,7 @@ class ThumbnailBackend(object):
                     # if S3Storage says file doesn't exist remotely, don't try to
                     # create it and exit early.
                     # Will return working empty image type; 404'd image
-                    logger.warn('Remote file [%s] at [%s] does not exist', file_, geometry_string)
+                    logger.warn(text_type('Remote file [%s] at [%s] does not exist'), file_, geometry_string)
                     return thumbnail
 
             # We might as well set the size since we have the image in memory
@@ -143,7 +143,7 @@ class ThumbnailBackend(object):
         """
         Creates the thumbnail by using default.engine
         """
-        logger.debug('Creating thumbnail file [%s] at [%s] with [%s]',
+        logger.debug(text_type('Creating thumbnail file [%s] at [%s] with [%s]'),
                      thumbnail.name, geometry_string, options)
         ratio = default.engine.get_image_ratio(source_image, options)
         geometry = parse_geometry(geometry_string, ratio)


### PR DESCRIPTION
This is a fix for issue #239. I'm not sure if it's the best way to handle the types with your compat module but it seems to work for me.
