### PR TITLE
Setting SORL_THUMBNAIL should be optional

### DIFF
--- a/sorl/thumbnail/templatetags/thumbnail.py
+++ b/sorl/thumbnail/templatetags/thumbnail.py
@@ -35,7 +35,7 @@ def safe_filter(error_output=''):
             try:
                 return f(*args, **kwargs)
             except Exception as err:
-                if settings.THUMBNAIL_DEBUG:
+                if sorl_settings.THUMBNAIL_DEBUG:
                     raise
                 logger.error('Thumbnail filter failed: %s' % err.message,
                              exc_info=sys.exc_info())
@@ -57,7 +57,7 @@ class ThumbnailNodeBase(Node):
         try:
             return self._render(context)
         except Exception:
-            if settings.THUMBNAIL_DEBUG:
+            if sorl_settings.THUMBNAIL_DEBUG:
                 raise
 
             error_message = 'Thumbnail tag failed'


### PR DESCRIPTION
By using sorl_settings, the default setting is picked up. If this patch isn't applied, `THUMBNAIL_DEBUG` needs to be explicitly set in the settings, or things go wrong: http://dpaste.com/hold/1759722/
