### PR TITLE
Better support for LA mode images in PIL engine

### DIFF
--- a/sorl/thumbnail/engines/pil_engine.py
+++ b/sorl/thumbnail/engines/pil_engine.py
@@ -94,7 +94,7 @@ class Engine(EngineBase):
         if colorspace == 'RGB':
             if image.mode == 'RGBA':
                 return image  # RGBA is just RGB + Alpha
-            if image.mode == 'P' and 'transparency' in image.info:
+            if image.mode == 'LA' or (image.mode == 'P' and 'transparency' in image.info):
                 return image.convert('RGBA')
             return image.convert('RGB')
         if colorspace == 'GRAY':


### PR DESCRIPTION
This allows LA mode images (i.e. greyscale with transparency) to preserve their transparency when using the RGB colorspace.

Without this fix, the resulting thumbnail gets filled with black color.
