### PR TITLE
adding placereddit logic to the dummy thumbnail

### DIFF
--- a/sorl/thumbnail/images.py
+++ b/sorl/thumbnail/images.py
@@ -1,4 +1,6 @@
 import re
+import urllib2
+import random
 
 from django.core.files.base import File, ContentFile
 from django.core.files.storage import Storage, default_storage
@@ -173,6 +175,14 @@ class DummyImageFile(BaseImageFile):
 
     @property
     def url(self):
+        if settings.THUMBNAIL_DUMMY_SOURCE == 'placereddit':
+            reddit = random.choice(getattr(settings,'THUMBNAIL_SUBREDDITS',['featured']))
+            n = random.choice(range(10))
+            if '/' in reddit:
+                url = 'http://placereddit.com/%s/%s/%s/%s/'
+            else:
+                url = 'http://placereddit.com/r/%s/%s/%s/%s/'
+            return url%(reddit,self.x,self.y,n)
         return settings.THUMBNAIL_DUMMY_SOURCE % (
             {'width': self.x, 'height': self.y}
         )


### PR DESCRIPTION
I've created a service that serves placeholder images called placereddit.com which is similar to placehold.it and placekitten. It's got a slightly different API that justifies modifying images.py and for the past year I've been using my own sorl fork for a year without issue. I told a few people at django con about my site and would like the larger community to start using this resource. It's impractical to have them use my fork, hence this pull request. This won't affect other functionality in sorl-thumbnail. Please merge.
