### PR TITLE
More backward compatible image_info option processing

### DIFF
--- a/sorl/thumbnail/engines/base.py
+++ b/sorl/thumbnail/engines/base.py
@@ -133,7 +133,7 @@ class EngineBase(object):
         """
         format_ = options['format']
         quality = options['quality']
-        image_info = options['image_info']
+        image_info = options.get('image_info', {})
         # additional non-default-value options:
         progressive = options.get('progressive', settings.THUMBNAIL_PROGRESSIVE)
         raw_data = self._get_raw_data(


### PR DESCRIPTION
Some older (but useful) sorl engines may not pass 'image_info' to write method. This lead to KeyError when using with sorl >= 11.12.1b
