### PR TITLE
fix #309

### DIFF
--- a/sorl/thumbnail/base.py
+++ b/sorl/thumbnail/base.py
@@ -42,11 +42,11 @@ class ThumbnailBackend(object):
         ('blur', 'THUMBNAIL_BLUR'),
     )
 
-    def file_extension(self, file_):
-        return os.path.splitext(file_.name)[1].lower()
+    def file_extension(self, source):
+        return os.path.splitext(source.name)[1].lower()
 
-    def _get_format(self, file_):
-        file_extension = self.file_extension(file_)
+    def _get_format(self, source):
+        file_extension = self.file_extension(source)
 
         if file_extension == '.jpg' or file_extension == '.jpeg':
             return 'JPEG'
@@ -74,7 +74,7 @@ class ThumbnailBackend(object):
 
         #preserve image filetype
         if settings.THUMBNAIL_PRESERVE_FORMAT:
-            options.setdefault('format', self._get_format(file_))
+            options.setdefault('format', self._get_format(source))
 
         for key, value in self.default_options.items():
             options.setdefault(key, value)

--- a/tests/thumbnail_tests/tests.py
+++ b/tests/thumbnail_tests/tests.py
@@ -803,3 +803,6 @@ class PreserveFormatTest(TestCase):
 
     def test_with_nonascii(self):
         self.assertEqual(self.backend._get_format(FakeFile('你好.jpg')), 'JPEG')
+
+    def test_image_remote_url(self):
+        self.assertEqual(self.backend._get_format(FakeFile('http://example.com/1.png')), 'PNG')


### PR DESCRIPTION
this is a very naive patch for #309.  

determining the format of a file by its extension is a very fragile approach, specially for remote images. 
For example, this is a valid JPEG image 
https://encrypted-tbn1.gstatic.com/images?q=tbn:ANd9GcTgEmgnOC8Q_efV74QG4IizYVycmOz2f23yQbYwtmYAv4XqH9zEzA but would fail checking by its "extension" 

 a better way should be read the file and check it via [imghdr](https://docs.python.org/2/library/imghdr.html) from the python stdlib
