### PR TITLE
Fix #312 - Make caching keys based on the original name of the thumbnail...

### DIFF
--- a/sorl/thumbnail/base.py
+++ b/sorl/thumbnail/base.py
@@ -65,6 +65,7 @@ class ThumbnailBackend(object):
         """
         logger.debug(text_type('Getting thumbnail for file [%s] at [%s]'), file_,
                      geometry_string)
+
         if file_:
             source = ImageFile(file_)
         elif settings.THUMBNAIL_DUMMY:
@@ -79,7 +80,6 @@ class ThumbnailBackend(object):
         for key, value in self.default_options.items():
             options.setdefault(key, value)
 
-
         # For the future I think it is better to add options only if they
         # differ from the default settings as below. This will ensure the same
         # filenames being generated for new options at default.
@@ -88,7 +88,7 @@ class ThumbnailBackend(object):
             if value != getattr(default_settings, attr):
                 options.setdefault(key, value)
         name = self._get_thumbnail_filename(source, geometry_string, options)
-        thumbnail = ImageFile(name, default.storage)
+        thumbnail = ImageFile(name, default.storage, key=tokey(source.key, geometry_string, serialize(options)))
         cached = default.kvstore.get(thumbnail)
         if cached:
             return cached
@@ -108,6 +108,7 @@ class ThumbnailBackend(object):
                     logger.warn(text_type('Remote file [%s] at [%s] does not exist'), file_, geometry_string)
                     return thumbnail
 
+            
             # We might as well set the size since we have the image in memory
             image_info = default.engine.get_image_info(source_image)
             options['image_info'] = image_info
@@ -120,6 +121,7 @@ class ThumbnailBackend(object):
                                                      options, thumbnail.name)
             finally:
                 default.engine.cleanup(source_image)
+
 
         # If the thumbnail exists we don't create it, the other option is
         # to delete and write but this could lead to race conditions so I

--- a/sorl/thumbnail/images.py
+++ b/sorl/thumbnail/images.py
@@ -75,7 +75,7 @@ class BaseImageFile(object):
 class ImageFile(BaseImageFile):
     _size = None
 
-    def __init__(self, file_, storage=None):
+    def __init__(self, file_, storage=None, key=None):
         if not file_:
             raise ThumbnailError('File is empty.')
 
@@ -84,6 +84,9 @@ class ImageFile(BaseImageFile):
             self.name = file_.name
         else:
             self.name = force_unicode(file_)
+            
+        if key:
+            self._key = key
 
         # figure out storage
         if storage is not None:
@@ -155,7 +158,9 @@ class ImageFile(BaseImageFile):
 
     @property
     def key(self):
-        return tokey(self.name, self.serialize_storage())
+        if not hasattr(self, '_key'):
+            self._key = tokey(self.name, self.serialize_storage())
+        return self._key
 
     def serialize(self):
         return serialize_image_file(self)


### PR DESCRIPTION
..., not the storage's name which can add _1, _2, _3, etc.
