### PR TITLE
Fix broken cropping with upscale=False

### DIFF
--- a/sorl/thumbnail/engines/base.py
+++ b/sorl/thumbnail/engines/base.py
@@ -88,7 +88,6 @@ class EngineBase(object):
         crop = options['crop']
         upscale = options['upscale']
         x_image, y_image = self.get_image_size(image)
-        factor = self._calculate_scaling_factor(x_image, y_image, geometry, options)
 
         if not crop or crop == 'noop':
             return image


### PR DESCRIPTION
Currently, images don't crop at all when upscale=False - this is because they are already scaled ready for cropping, so `factor` here is always 1.0. We could change the `>=` to just `>`, but then there'd still be the problem that, say, a 400x300 image with crop geometry 300x400 would end up bigger than the crop box, so I think the solution below is best.
