### PR TITLE
Update test settings and utils for Django1.7

### DIFF
--- a/tests/settings/default.py
+++ b/tests/settings/default.py
@@ -25,10 +25,17 @@ MEDIA_ROOT = pjoin(PROJ_ROOT, 'media')
 MEDIA_URL = '/media/'
 ROOT_URLCONF = 'thumbnail_tests.urls'
 INSTALLED_APPS = (
-    'thumbnail',
-    'thumbnail_tests',
+    'sorl.thumbnail',
+    'tests.thumbnail_tests',
 )
 TEMPLATE_CONTEXT_PROCESSORS = (
     "django.core.context_processors.request",
 )
-
+MIDDLEWARE_CLASSES = (
+    'django.contrib.sessions.middleware.SessionMiddleware',
+    'django.middleware.common.CommonMiddleware',
+    'django.middleware.csrf.CsrfViewMiddleware',
+    'django.contrib.auth.middleware.AuthenticationMiddleware',
+    'django.contrib.messages.middleware.MessageMiddleware',
+    'django.middleware.clickjacking.XFrameOptionsMiddleware',
+)

--- a/tests/thumbnail_tests/utils.py
+++ b/tests/thumbnail_tests/utils.py
@@ -51,7 +51,7 @@ class override_custom_settings(object):
         self.settings._wrapped = override
         for key, new_value in self.options.items():
             setting_changed.send(sender=self.settings._wrapped.__class__,
-                                 setting=key, value=new_value)
+                                 setting=key, value=new_value, enter=True)
 
     def disable(self):
         self.settings._wrapped = self.wrapped
@@ -59,4 +59,4 @@ class override_custom_settings(object):
         for key in self.options:
             new_value = getattr(self.settings, key, None)
             setting_changed.send(sender=self.settings._wrapped.__class__,
-                                 setting=key, value=new_value)
+                                 setting=key, value=new_value, enter=False)

--- a/tests/thumbnail_tests/views.py
+++ b/tests/thumbnail_tests/views.py
@@ -5,4 +5,4 @@ from django.http import HttpResponse
 def direct_to_template(request, template, mimetype=None, **kwargs):
     c = RequestContext(request, {})
     t = loader.get_template(template)
-    return HttpResponse(t.render(c), mimetype=mimetype)
+    return HttpResponse(t.render(c), content_type=mimetype)


### PR DESCRIPTION
- Set package name explicitly on INSTALLED_APPS. Fixes "Item" import
  issue.
- Add MIDDLEWARE_CLASSES to suppress warning.
- Add "enter" keyword to util sending `setting_changed` signal:
  https://docs.djangoproject.com/en/dev/releases/1.7/#signals
- Change `mimetype` to `content_type`
  https://docs.djangoproject.com/en/dev/releases/1.7/#features-removed-in-1-7

After this changeset, all tests pass with the exception of exif orientation checks which seem to differ between some backends.
