### PR TITLE
fix #140, Make KVStore not managed when redis is used

### DIFF
--- a/sorl/thumbnail/models.py
+++ b/sorl/thumbnail/models.py
@@ -11,3 +11,6 @@ class KVStore(models.Model):
 
     def __unicode__(self):
         return self.key
+
+    class Meta:
+        managed = settings.THUMBNAIL_KVSTORE != 'sorl.thumbnail.kvstores.redis_kvstore.KVStore'


### PR DESCRIPTION
This will make sure that django does not create the table when redis
kvstore is used.
