### PR TITLE
Fix a compatibility issue of the DBM KV Store

### DIFF
--- a/sorl/thumbnail/kvstores/dbm_kvstore.py
+++ b/sorl/thumbnail/kvstores/dbm_kvstore.py
@@ -66,7 +66,10 @@ class KVStore(KVStoreBase):
 
     def _get_raw(self, key):
         with DBMContext(self.filename, self.mode, True) as db:
-            return db.get(self._cast_key(key))
+            try:
+                return db[self._cast_key(key)]
+            except KeyError:
+                return None
 
     def _set_raw(self, key, value):
         with DBMContext(self.filename, self.mode, False) as db:
@@ -75,9 +78,10 @@ class KVStore(KVStoreBase):
     def _delete_raw(self, *keys):
         with DBMContext(self.filename, self.mode, False) as db:
             for key in keys:
-                k = self._cast_key(key)
-                if k in db:
-                    del db[k]
+                try:
+                    del db[self._cast_key(key)]
+                except KeyError:
+                    pass
 
     def _find_keys_raw(self, prefix):
         with DBMContext(self.filename, self.mode, True) as db:


### PR DESCRIPTION
There is a mistake in the DBM KV Store implementation.  Across the different DBM module implementations, the only consistent interface for database objects is the mapping interface.  In particular, the `.get()` method is not supported in all of them.  So, in some installations, it happens that the DBM store raises `AttributeError` when trying to get a thumbnail key.
