### PR TITLE
Fix travis building of tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -81,7 +81,7 @@ install:
 
 script:
   - cd tests && coverage run --source=sorl runtests.py --settings=settings.$SETTINGS
-  - flake8
+  - cd .. && flake8
 
 services:
   - redis-server


### PR DESCRIPTION
Travis isn't currently marking builds with failing tests as broken! It's funny because I thought I ran the tests on my local machine first but I guess maybe I forgot, assuming Travis would flag up any problems. I've also changed it build pushes to all branches rather than just master which I think is a good idea since this allows us to catch problems as early as possible. (The same reason why probably best to run the tests locally first! Oops!) I'll make another pull request to fix the tests in a minute.
