### PR TITLE
KeyError: u'JPG'

### DIFF
--- a/sorl/thumbnail/admin/current.py
+++ b/sorl/thumbnail/admin/current.py
@@ -23,7 +23,7 @@ class AdminImageWidget(forms.ClearableFileInput):
     def render(self, name, value, attrs=None):
         output = super(AdminImageWidget, self).render(name, value, attrs)
         if value and hasattr(value, 'url'):
-            ext = 'JPG'
+            ext = 'JPEG'
             try:
                 aux_ext = str(value).split('.')
                 if aux_ext[len(aux_ext) - 1].lower() == 'png':


### PR DESCRIPTION
JPG causes a KeyError: u'JPG' in 

sorl/thumbnail/base.py", line 196, in _get_thumbnail_filename
  EXTENSIONS[options['format']])

because there is JPEG used instead of JPG:

base.py:
EXTENSIONS = {
    'JPEG': 'jpg',
    'PNG': 'png',
}
