### PR TITLE
Fix html_filter and markdown_filter using absolute paths to images

### DIFF
--- a/sorl/thumbnail/templatetags/thumbnail.py
+++ b/sorl/thumbnail/templatetags/thumbnail.py
@@ -255,7 +255,7 @@ def text_filter(regex_base, value):
     for i in images:
         image = i[1]
         if image.startswith(settings.MEDIA_URL):
-            image = image.replace(settings.MEDIA_URL, '%s/' % settings.MEDIA_ROOT)
+            image = image[len(settings.MEDIA_URL):]
 
         im = get_thumbnail(image, str(sorl_settings.THUMBNAIL_FILTER_WIDTH))
         value = value.replace(i[1], im.url)

--- a/tests/thumbnail_tests/tests.py
+++ b/tests/thumbnail_tests/tests.py
@@ -406,7 +406,7 @@ class SimpleTestCase(SimpleTestCaseBase):
         }).strip()
         self.assertEqual(
             '<img alt="A image!" '
-            'src="/media/test/cache/73/4c/734c426a910415e59dc0aebce5d13b2c.jpg" />',
+            'src="/media/test/cache/36/1f/361fdc861e17bc1d108844b980454627.jpg" />',
             val
         )
 
@@ -426,7 +426,7 @@ class SimpleTestCase(SimpleTestCaseBase):
             'text': text,
         }).strip()
         self.assertEqual(
-            '![A image!](/media/test/cache/73/4c/734c426a910415e59dc0aebce5d13b2c.jpg)',
+            '![A image!](/media/test/cache/36/1f/361fdc861e17bc1d108844b980454627.jpg)',
             val
         )
 


### PR DESCRIPTION
This made hashes in tests dependent on sorl-thumbnail's root. See comments on https://github.com/mariocesar/sorl-thumbnail/pull/330 . Also fix corresponding hashes. There is a bigger issue here: https://github.com/mariocesar/sorl-thumbnail/issues/283 , but I would propose to do the opposite: whenever there is a possibility, make paths relative to MEDIA_ROOT. This allows copying everything in MEDIA_ROOT to another machine with a different MEDIA_ROOT for example, and avoids issues like this with the tests.
