### PR TITLE
Normalise image names to be relative (to MEDIA_ROOT) whenever possible

### DIFF
--- a/sorl/thumbnail/images.py
+++ b/sorl/thumbnail/images.py
@@ -95,6 +95,13 @@ class ImageFile(BaseImageFile):
         else:
             self.storage = default_storage
 
+        if hasattr(self.storage, 'location'):
+            location = self.storage.location
+            if not self.storage.location.endswith("/"):
+                location += "/"
+            if self.name.startswith(self.storage.location):
+                self.name = self.name[len(location):]
+
     def __unicode__(self):
         return self.name
 

--- a/tests/thumbnail_tests/tests.py
+++ b/tests/thumbnail_tests/tests.py
@@ -430,6 +430,12 @@ class SimpleTestCase(SimpleTestCaseBase):
             val
         )
 
+    def test_relative_absolute_same_key(self):
+        image = Item.objects.get(image='500x500.jpg').image
+        imref1 = ImageFile(image.name)
+        imref2 = ImageFile(pjoin(settings.MEDIA_ROOT, image.name))
+        self.assertEqual(imref1.key, imref2.key)
+
 
 class TemplateTestCaseA(SimpleTestCaseBase):
     def test_model(self):


### PR DESCRIPTION
This prevents the same image getting more than one thumbnail. See https://github.com/mariocesar/sorl-thumbnail/issues/283 although this fix is the opposite to the one outlined there since this makes it possible to have things match between environments with a different MEDIA_ROOT. This is useful for if things are moved between machines and for writing tests.
