### PR TITLE
Feature/travis container

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,17 +4,14 @@ python:
   - "3.4"
 
 sudo: false
-   
+
 addons:
   apt:
     packages:
-      - libjpeg62 
-      - libjpeg62-dev
-      - zlib1g-dev
-      - imagemagick
-      - graphicsmagick
-      - libgraphicsmagick++1-dev
-      - libboost-python-dev
+    - libgraphicsmagick1-dev
+    - libgraphicsmagick++1-dev
+    - libboost-python-dev
+    - graphicsmagick
 
 cache:
   apt: true
@@ -23,62 +20,62 @@ cache:
     - .tox
 
 env:
-  - TOX_ENV=py27-django14-pil APT='libjpeg62 libjpeg62-dev zlib1g-dev'
-  - TOX_ENV=py27-django14-imagemagick APT=imagemagick
-  - TOX_ENV=py27-django14-graphicsmagick APT=graphicsmagick
+  - TOX_ENV=py27-django14-pil
+  - TOX_ENV=py27-django14-imagemagick
+  - TOX_ENV=py27-django14-graphicsmagick
   - TOX_ENV=py27-django14-redis
   - TOX_ENV=py27-django14-wand
-  - TOX_ENV=py27-django14-pgmagick APT='libgraphicsmagick++1-dev libboost-python-dev'
+  - TOX_ENV=py27-django14-pgmagick
   - TOX_ENV=py27-django14-dbm
-  - TOX_ENV=py27-django15-pil APT='libjpeg62 libjpeg62-dev zlib1g-dev'
-  - TOX_ENV=py27-django15-imagemagick APT=imagemagick
-  - TOX_ENV=py27-django15-graphicsmagick APT=graphicsmagick
+  - TOX_ENV=py27-django15-pil
+  - TOX_ENV=py27-django15-imagemagick
+  - TOX_ENV=py27-django15-graphicsmagick
   - TOX_ENV=py27-django15-redis
   - TOX_ENV=py27-django15-wand
-  - TOX_ENV=py27-django15-pgmagick APT='libgraphicsmagick++1-dev libboost-python-dev'
+  - TOX_ENV=py27-django15-pgmagick
   - TOX_ENV=py27-django15-dbm
-  - TOX_ENV=py27-django16-pil APT='libjpeg62 libjpeg62-dev zlib1g-dev'
-  - TOX_ENV=py27-django16-imagemagick APT=imagemagick
-  - TOX_ENV=py27-django16-graphicsmagick APT=graphicsmagick
+  - TOX_ENV=py27-django16-pil
+  - TOX_ENV=py27-django16-imagemagick
+  - TOX_ENV=py27-django16-graphicsmagick
   - TOX_ENV=py27-django16-redis
   - TOX_ENV=py27-django16-wand
-  - TOX_ENV=py27-django16-pgmagick APT='libgraphicsmagick++1-dev libboost-python-dev'
+  - TOX_ENV=py27-django16-pgmagick
   - TOX_ENV=py27-django16-dbm
-  - TOX_ENV=py27-django17-pil APT='libjpeg62 libjpeg62-dev zlib1g-dev'
-  - TOX_ENV=py27-django17-imagemagick APT=imagemagick
-  - TOX_ENV=py27-django17-graphicsmagick APT=graphicsmagick
+  - TOX_ENV=py27-django17-pil
+  - TOX_ENV=py27-django17-imagemagick
+  - TOX_ENV=py27-django17-graphicsmagick
   - TOX_ENV=py27-django17-redis
   - TOX_ENV=py27-django17-wand
-  - TOX_ENV=py27-django17-pgmagick APT='libgraphicsmagick++1-dev libboost-python-dev'
+  - TOX_ENV=py27-django17-pgmagick
   - TOX_ENV=py27-django17-dbm
-  - TOX_ENV=py27-django18-pil APT='libjpeg62 libjpeg62-dev zlib1g-dev'
-  - TOX_ENV=py27-django18-imagemagick APT=imagemagick
-  - TOX_ENV=py27-django18-graphicsmagick APT=graphicsmagick
+  - TOX_ENV=py27-django18-pil
+  - TOX_ENV=py27-django18-imagemagick
+  - TOX_ENV=py27-django18-graphicsmagick
   - TOX_ENV=py27-django18-redis
   - TOX_ENV=py27-django18-wand
-  - TOX_ENV=py27-django18-pgmagick APT='libgraphicsmagick++1-dev libboost-python-dev'
+  - TOX_ENV=py27-django18-pgmagick
   - TOX_ENV=py27-django18-dbm
-  - TOX_ENV=py34-django15-pil APT='libjpeg62 libjpeg62-dev zlib1g-dev'
-  - TOX_ENV=py34-django15-imagemagick APT=imagemagick
-  - TOX_ENV=py34-django15-graphicsmagick APT=graphicsmagick
+  - TOX_ENV=py34-django15-pil
+  - TOX_ENV=py34-django15-imagemagick
+  - TOX_ENV=py34-django15-graphicsmagick
   - TOX_ENV=py34-django15-redis
   - TOX_ENV=py34-django15-wand
   - TOX_ENV=py34-django15-dbm
-  - TOX_ENV=py34-django16-pil APT='libjpeg62 libjpeg62-dev zlib1g-dev'
-  - TOX_ENV=py34-django16-imagemagick APT=imagemagick
-  - TOX_ENV=py34-django16-graphicsmagick APT=graphicsmagick
+  - TOX_ENV=py34-django16-pil
+  - TOX_ENV=py34-django16-imagemagick
+  - TOX_ENV=py34-django16-graphicsmagick
   - TOX_ENV=py34-django16-redis
   - TOX_ENV=py34-django16-wand
   - TOX_ENV=py34-django16-dbm
-  - TOX_ENV=py34-django17-pil APT='libjpeg62 libjpeg62-dev zlib1g-dev'
-  - TOX_ENV=py34-django17-imagemagick APT=imagemagick
-  - TOX_ENV=py34-django17-graphicsmagick APT=graphicsmagick
+  - TOX_ENV=py34-django17-pil
+  - TOX_ENV=py34-django17-imagemagick
+  - TOX_ENV=py34-django17-graphicsmagick
   - TOX_ENV=py34-django17-redis
   - TOX_ENV=py34-django17-wand
   - TOX_ENV=py34-django17-dbm
-  - TOX_ENV=py34-django18-pil APT='libjpeg62 libjpeg62-dev zlib1g-dev'
-  - TOX_ENV=py34-django18-imagemagick APT=imagemagick
-  - TOX_ENV=py34-django18-graphicsmagick APT=graphicsmagick
+  - TOX_ENV=py34-django18-pil
+  - TOX_ENV=py34-django18-imagemagick
+  - TOX_ENV=py34-django18-graphicsmagick
   - TOX_ENV=py34-django18-redis
   - TOX_ENV=py34-django18-wand
   - TOX_ENV=py34-django18-dbm

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,16 +8,47 @@ sudo: false
 addons:
   apt:
     packages:
-    - libgraphicsmagick1-dev
-    - libgraphicsmagick++1-dev
-    - libboost-python-dev
-    - graphicsmagick
+      - libgraphicsmagick1-dev
+      - libgraphicsmagick++1-dev
+      - libboost-python-dev
+      - graphicsmagick
 
-cache:
-  apt: true
-  pip: true
-  directories:
-    - .tox
+services:
+  - redis-server
+
+install:
+  - pip install --upgrade pip wheel
+  - pip install -q coveralls flake8 tox
+
+script:
+  - env | sort
+  - tox -e $TOX_ENV
+  - flake8 --show-source sorl/
+
+after_failure:
+ - cat /home/travis/.pip/pip.log
+
+after_success:
+ - coveralls
+
+notifications:
+ irc:
+   channels:
+     - "irc.freenode.org#sorl-thumbnail"
+   on_success: change
+   on_failure: change
+ webhooks:
+   urls:
+     - https://webhooks.gitter.im/e/b368c47d69637f9a01a0
+   on_success: change
+   on_failure: change
+   on_start: false     # default: false
+
+# cache:
+#  apt: true
+#  pip: true
+#  directories:
+#    - .tox
 
 env:
   - TOX_ENV=py27-django14-pil
@@ -79,34 +110,3 @@ env:
   - TOX_ENV=py34-django18-redis
   - TOX_ENV=py34-django18-wand
   - TOX_ENV=py34-django18-dbm
-
-after_failure:
-  - cat /home/travis/.pip/pip.log
-
-after_success:
-  - coveralls
-
-install:
-  - pip install pip wheel
-  - pip install -q coveralls flake8 tox
-
-script:
-  - env | sort
-  - tox -e $TOX_ENV
-  - flake8 --show-source sorl/
-
-services:
-  - redis-server
-
-notifications:
-  irc:
-    channels:
-      - "irc.freenode.org#sorl-thumbnail"
-    on_success: change
-    on_failure: change
-  webhooks:
-    urls:
-      - https://webhooks.gitter.im/e/b368c47d69637f9a01a0
-    on_success: change
-    on_failure: change
-    on_start: false     # default: false

--- a/.travis.yml
+++ b/.travis.yml
@@ -17,7 +17,8 @@ addons:
       - libboost-python-dev
 
 cache:
-  pip:
+  apt: true
+  pip: true
   directories:
     - .tox
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,9 +3,21 @@ language: python
 python:
   - "3.4"
 
+sudo: false
+   
+addons:
+  apt:
+    packages:
+      - libjpeg62 
+      - libjpeg62-dev
+      - zlib1g-dev
+      - imagemagick
+      - graphicsmagick
+      - libgraphicsmagick++1-dev
+      - libboost-python-dev
+
 cache:
   pip:
-  apt:
   directories:
     - .tox
 
@@ -69,10 +81,6 @@ env:
   - TOX_ENV=py34-django18-redis
   - TOX_ENV=py34-django18-wand
   - TOX_ENV=py34-django18-dbm
-
-before_install:
-  - sudo apt-get update -qq
-  - sudo apt-get install -qq $APT
 
 after_failure:
   - cat /home/travis/.pip/pip.log


### PR DESCRIPTION
Issue #410 

I don't expect this to work on the first try. Container based Travis does not support regular `sudo apt-get`, but you can use `addons.apt.packages` instead. 
http://docs.travis-ci.com/user/migrating-from-legacy/?utm_source=legacy-notice&utm_medium=banner&utm_campaign=legacy-upgrade#How-do-I-install-APT-sources-and-packages%3F
