### PR TITLE
Fix #490: Use Popen.returncode to determin if calls to `convert` process is successful or not

### DIFF
--- a/sorl/thumbnail/engines/convert_engine.py
+++ b/sorl/thumbnail/engines/convert_engine.py
@@ -53,10 +53,10 @@ class Engine(EngineBase):
             args.append(fp.name)
             args = map(smart_str, args)
             p = subprocess.Popen(args, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
-            p.wait()
+            returncode = p.wait()
             out, err = p.communicate()
 
-            if err:
+            if returncode:
                 raise Exception(err)
 
             thumbnail.write(fp.read())


### PR DESCRIPTION
Before, the test was done on the fact that convert outputs things on stderr. It appears that `convert` may output warnings on stderr but still be ok at the end.