### PR TITLE
Fix RGBA mode not compatible with JPEG on Pillow >=3.7

### DIFF
--- a/sorl/thumbnail/engines/pil_engine.py
+++ b/sorl/thumbnail/engines/pil_engine.py
@@ -65,6 +65,15 @@ class Engine(EngineBase):
             return False
         return True
 
+    def colorspace(self, image, geometry, options):
+        """
+        Wrapper for ``_colorspace``
+        """
+        colorspace = options['colorspace']
+        format = options['format']
+
+        return self._colorspace(image, colorspace, format)
+
     def _cropbox(self, image, x, y, x2, y2):
         return image.crop((x, y, x2, y2))
 
@@ -106,9 +115,10 @@ class Engine(EngineBase):
 
         return False
 
-    def _colorspace(self, image, colorspace):
+    def _colorspace(self, image, colorspace, format):
         if colorspace == 'RGB':
-            if image.mode == 'RGBA':
+            # Pillow JPEG doesn't allow RGBA anymore. It was converted to RGB before.
+            if image.mode == 'RGBA' and format != 'JPEG':
                 return image  # RGBA is just RGB + Alpha
             if image.mode == 'LA' or (image.mode == 'P' and 'transparency' in image.info):
                 newimage = image.convert('RGBA')

--- a/tests/thumbnail_tests/test_engines.py
+++ b/tests/thumbnail_tests/test_engines.py
@@ -233,6 +233,13 @@ class SimpleTestCase(BaseTestCase):
         imref2 = ImageFile(os.path.join(settings.MEDIA_ROOT, image.name))
         self.assertEqual(imref1.key, imref2.key)
 
+    def test_rgba_colorspace(self):
+        item = Item.objects.get(image='500x500.jpg')
+
+        t = self.BACKEND.get_thumbnail(item.image, '100x100', colorspace="RGBA", format="JPEG")
+        self.assertEqual(t.x, 100)
+        self.assertEqual(t.y, 100)
+
 
 class CropTestCase(BaseTestCase):
     def setUp(self):

--- a/tests/thumbnail_tests/test_engines.py
+++ b/tests/thumbnail_tests/test_engines.py
@@ -233,6 +233,7 @@ class SimpleTestCase(BaseTestCase):
         imref2 = ImageFile(os.path.join(settings.MEDIA_ROOT, image.name))
         self.assertEqual(imref1.key, imref2.key)
 
+    @unittest.skipIf('pil_engine' not in settings.THUMBNAIL_ENGINE, 'RGBA is only supported in PIL')
     def test_rgba_colorspace(self):
         item = Item.objects.get(image='500x500.jpg')
 


### PR DESCRIPTION
This is basically #504 (by @Darou) + the test that was asked for by @Flimm.

Fixes #503.