### PR TITLE
Avoid error "missing file_ argument in get_thumbnail()"

### DIFF
--- a/sorl/thumbnail/base.py
+++ b/sorl/thumbnail/base.py
@@ -77,11 +77,7 @@ class ThumbnailBackend(object):
         if file_:
             source = ImageFile(file_)
         else:
-            if settings.THUMBNAIL_DUMMY:
-                return DummyImageFile(geometry_string)
-            else:
-                logger.error('missing file_ argument in get_thumbnail()')
-                return
+            raise ValueError('falsey file_ argument in get_thumbnail()')
 
         # preserve image filetype
         if settings.THUMBNAIL_PRESERVE_FORMAT:

--- a/sorl/thumbnail/templatetags/thumbnail.py
+++ b/sorl/thumbnail/templatetags/thumbnail.py
@@ -135,7 +135,11 @@ class ThumbnailNode(ThumbnailNodeBase):
             else:
                 options[key] = value
 
-        thumbnail = get_thumbnail(file_, geometry, **options)
+        thumbnail = None
+        if file_:
+            thumbnail = get_thumbnail(file_, geometry, **options)
+        elif sorl_settings.THUMBNAIL_DUMMY:
+            thumbnail = DummyImageFile(geometry)
 
         if not thumbnail or (isinstance(thumbnail, DummyImageFile) and self.nodelist_empty):
             if self.nodelist_empty:

--- a/tests/thumbnail_tests/test_engines.py
+++ b/tests/thumbnail_tests/test_engines.py
@@ -242,6 +242,13 @@ class SimpleTestCase(BaseTestCase):
         self.assertEqual(t.y, 100)
 
 
+    def test_falsey_file_argument(self):
+        with self.assertRaises(ValueError):
+            self.BACKEND.get_thumbnail('', '100x100')
+        with self.assertRaises(ValueError):
+            self.BACKEND.get_thumbnail(None, '100x100')
+
+
 class CropTestCase(BaseTestCase):
     def setUp(self):
         super(CropTestCase, self).setUp()


### PR DESCRIPTION
Before, sorl-thumbnail  would log these error messages:

> missing file_ argument in get_thumbnail()

This pull request removes that behaviour. The `{% empty %}` section still works as expected, and `get_thumbnail` will throw an exception if passed a falsey image.

Fixes #526

I'm posting this as a pull request, because I would like a second opinion on whether this is the right way forward.