### PR TITLE
Test in Python 3.7

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -57,6 +57,12 @@ matrix:
     - python: "3.6"
       env: TOXENV=py36-django21-dbm
 
+    - python: "3.7-dev"
+      env: TOXENV=py37-django20-pil
+
+    - python: "3.7-dev"
+      env: TOXENV=py37-django21-pil
+
 sudo: false
 dist: trusty
 

--- a/setup.py
+++ b/setup.py
@@ -37,6 +37,7 @@ setup(
         'Programming Language :: Python :: 3.4',
         'Programming Language :: Python :: 3.5',
         'Programming Language :: Python :: 3.6',
+        'Programming Language :: Python :: 3.7',
         'Topic :: Internet :: WWW/HTTP :: Dynamic Content',
         'Topic :: Multimedia :: Graphics',
         'Framework :: Django',

--- a/tox.ini
+++ b/tox.ini
@@ -3,8 +3,8 @@
 [tox]
 skipsdist = True
 envlist = {py27,py34,py35,py36}-django111-{pil,imagemagick,graphicsmagick,redis,dynamodb,wand,pgmagick,dbm,vipsthumbnail}
-          {py34,py35,py36}-django20-{pil,imagemagick,graphicsmagick,redis,dynamodb,wand,pgmagick,dbm,vipsthumbnail}
-          {py35,py36}-django21-{pil,imagemagick,graphicsmagick,redis,dynamodb,wand,pgmagick,dbm,vipsthumbnail}
+          {py34,py35,py36,py37}-django20-{pil,imagemagick,graphicsmagick,redis,dynamodb,wand,pgmagick,dbm,vipsthumbnail}
+          {py35,py36,py37}-django21-{pil,imagemagick,graphicsmagick,redis,dynamodb,wand,pgmagick,dbm,vipsthumbnail}
 
 [testenv]
 changedir = {toxinidir}/tests


### PR DESCRIPTION
Travis CI only supports 3.7-dev so far, so we have to use `3.7-dev` instead of `3.7`.