### PR TITLE
Fix format conversion in Wand engine

### DIFF
--- a/sorl/thumbnail/engines/wand_engine.py
+++ b/sorl/thumbnail/engines/wand_engine.py
@@ -78,4 +78,6 @@ class Engine(EngineBase):
         image.compression_quality = quality
         if format_ == 'JPEG' and progressive:
             image.format = 'pjpeg'
+        else:
+            image.format = format_
         return image.make_blob()


### PR DESCRIPTION
Format has not been set correctly and always remained default (as image uploaded).