### PR TITLE
Adding a Free Transform option

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -130,7 +130,7 @@ You can use the 'get_thumbnail'::
 
 See more examples in the section `Low level API examples`_ in the Documentation
 
-Using in combination with other thumbnalers
+Using in combination with other thumbnailers
 -------------------------------------------
 
 Alternatively, you load the templatetags by {% load sorl_thumbnail %}

--- a/docs/template.rst
+++ b/docs/template.rst
@@ -136,6 +136,12 @@ cropping options if you don't want to generate unnecessary thumbnails. In case
 you are wondering, sorl-thumbnail sorts the options so the order does not
 matter, same options but in different order will generate only one thumbnail.
 
+``transform``
+^^^^^^^^^^^
+Transform is a boolean and controls if the image will be free transformed to the 
+dimensions provided. If set to true, the image will be forcibly resized to the 
+supplied dimensions and stretch as needed. Defaults to ``False``.
+
 ``upscale``
 ^^^^^^^^^^^
 Upscale is a boolean and controls if the image can be upscaled or not. For

--- a/docs/template.rst
+++ b/docs/template.rst
@@ -103,6 +103,17 @@ engine means that you can easily subclass an engine and create new features
 like rounded corners or what ever processing you like. The options described
 below are how they are used and interpreted in the shipped engines.
 
+``cropbox``
+^^^^^^^^^^^
+This option is used to crop to a specific set of coordinates. ``cropbox`` takes
+``x, y, x2, y2`` as arguments to crop the image down via those set of coordinates.
+Note that ``cropbox`` is applied before ``crop``.
+
+.. code-block:: python
+    
+    img = get_thumbnail(sorl_img, cropbox="{0},{1},{2},{3}".format(
+                        x, y, x2, y2))
+
 ``crop``
 ^^^^^^^^
 This option is only used if both width and height is given. Crop behaves much
@@ -179,6 +190,9 @@ Images are not padded by default, but this can be changed by setting
 This is the color to use for padding the image. It defaults to ``#ffffff`` and
 can be globally set with the setting ``THUMBNAIL_PADDING_COLOR``.
 
+``rounded``
+^^^^^^^^^^^^
+Takes an integer for radius to round the corners of the image. Defaults to ``None``.
 
 ``options``
 ^^^^^^^^^^^

--- a/sorl/thumbnail/base.py
+++ b/sorl/thumbnail/base.py
@@ -39,6 +39,7 @@ class ThumbnailBackend(object):
         'rounded': None,
         'padding': settings.THUMBNAIL_PADDING,
         'padding_color': settings.THUMBNAIL_PADDING_COLOR,
+        'transform': False,
     }
 
     extra_options = (

--- a/sorl/thumbnail/engines/base.py
+++ b/sorl/thumbnail/engines/base.py
@@ -78,14 +78,18 @@ class EngineBase(object):
         Wrapper for ``_scale``
         """
         upscale = options['upscale']
+        transform = options['transform']
         x_image, y_image = map(float, self.get_image_size(image))
-        factor = self._calculate_scaling_factor(x_image, y_image, geometry, options)
 
-        if factor < 1 or upscale:
-            width = toint(x_image * factor)
-            height = toint(y_image * factor)
-            image = self._scale(image, width, height)
+        if not transform:
+            factor = self._calculate_scaling_factor(x_image, y_image, geometry, options)
 
+            if factor < 1 or upscale:
+                width = toint(x_image * factor)
+                height = toint(y_image * factor)
+                image = self._scale(image, width, height)
+            return image
+        image = self._scale(image, geometry[0], geometry[1])
         return image
 
     def crop(self, image, geometry, options):

--- a/tests/thumbnail_tests/test_engines.py
+++ b/tests/thumbnail_tests/test_engines.py
@@ -380,6 +380,67 @@ class CropTestCase(BaseTestCase):
         )
 
 
+class FreeTransformTestCase(BaseTestCase):
+    def setUp(self):
+        super(FreeTransformTestCase, self).setUp()
+
+        # portrait
+        name = 'portrait.jpg'
+        fn = os.path.join(settings.MEDIA_ROOT, name)
+        im = Image.new('L', (100, 200))
+        im.paste(255, (0, 0, 100, 100))
+        im.save(fn)
+        self.portrait = ImageFile(Item.objects.get_or_create(image=name)[0].image)
+        self.KVSTORE.delete(self.portrait)
+
+    @unittest.skipIf(
+        'pil_engine' not in settings.THUMBNAIL_ENGINE,
+        'the other engines fail this test',
+    )
+    def test_PIL_freetransform(self):
+
+        th = self.BACKEND.get_thumbnail(self.landscape, '100x100', transform=True)
+        engine = PILEngine()
+        im = engine.get_image(th)
+        self.assertEqual(im.width, 100)
+        self.assertEqual(im.height, 100)
+
+    @unittest.skipIf(
+        'convert_engine' not in settings.THUMBNAIL_ENGINE,
+        'the other engines fail this test',
+    )
+    def test_convert_engine_freetransform(self):
+        from sorl.thumbnail.engines import convert_engine as ConvertEngine
+        th = self.BACKEND.get_thumbnail(self.landscape, '100x100', transform=True)
+        engine = ConvertEngine()
+        im = engine.get_image(th)
+        self.assertEqual(im["size"], (100, 100))
+
+    @unittest.skipIf(
+        'wand_engine' not in settings.THUMBNAIL_ENGINE,
+        'the other engines fail this test',
+    )
+    def test_wand_engine_freetransform(self):
+        from sorl.thumbnail.engines import wand_engine as WandEngine
+        th = self.BACKEND.get_thumbnail(self.landscape, '100x100', transform=True)
+        engine = WandEngine()
+        im = engine.get_image(th)
+        self.assertEqual(im.width(100), 100)
+        self.assertEqual(im.height(100), 100)
+
+    @unittest.skipIf(
+        'pgmagick_engine' not in settings.THUMBNAIL_ENGINE,
+        'the other engines fail this test',
+    )
+    def test_pgmagick_engine_freetransform(self):
+        from sorl.thumbnail.engines import pgmagick_engine as PgmagickEngine
+        th = self.BACKEND.get_thumbnail(self.landscape, '100x100', transform=True)
+        engine = PgmagickEngine()
+        im = engine.get_image(th)
+        self.assertEqual(im.width(100), 100)
+        self.assertEqual(im.height(100), 100)
+
+
 class DummyTestCase(unittest.TestCase):
     def setUp(self):
         self.BACKEND = get_module_class(settings.THUMBNAIL_BACKEND)()


### PR DESCRIPTION
For those times when you do not want/need scaling with image ratio (for one reason or another). This option will forcibly rescale/stretch the image to the supplied dimensions.