### PR TITLE
 Fix #554: Fix AdminImageWidget with Django 2.1

### DIFF
--- a/sorl/thumbnail/admin/current.py
+++ b/sorl/thumbnail/admin/current.py
@@ -22,8 +22,8 @@ class AdminImageWidget(forms.ClearableFileInput):
     )
     template_with_clear = '<label>%(clear_checkbox_label)s: %(clear)s</label>'
 
-    def render(self, name, value, attrs=None):
-        output = super(AdminImageWidget, self).render(name, value, attrs)
+    def render(self, name, value, attrs=None, **kwargs):
+        output = super(AdminImageWidget, self).render(name, value, attrs, **kwargs)
         if value and hasattr(value, 'url'):
             ext = 'JPEG'
             try:

--- a/tests/thumbnail_tests/test_admin.py
+++ b/tests/thumbnail_tests/test_admin.py
@@ -1,0 +1,10 @@
+from django.test import SimpleTestCase
+from django.test.utils import override_settings
+
+from sorl.thumbnail.admin.current import AdminImageWidget
+
+
+class AdminImageWidgetTests(SimpleTestCase):
+    def test_render_renderer_argument(self):
+        w = AdminImageWidget()
+        self.assertHTMLEqual(w.render('name', 'value', renderer=None), '<input type="file" name="name">')


### PR DESCRIPTION
From the django 2.1 release notes:
> Support for Widget.render() methods without the renderer argument is removed.

With Django 2.1 the current widget will raise this exception:
> TypeError: render() got an unexpected keyword argument 'renderer'
