### PR TITLE
Add request to formfield_for_dbfield

### DIFF
--- a/sorl/thumbnail/admin/current.py
+++ b/sorl/thumbnail/admin/current.py
@@ -57,8 +57,8 @@ class AdminImageMixin(object):
     show nicer form widget
     """
 
-    def formfield_for_dbfield(self, db_field, **kwargs):
+    def formfield_for_dbfield(self, db_field, request, **kwargs):
         if isinstance(db_field, ImageField):
             return db_field.formfield(widget=AdminImageWidget)
         sup = super(AdminImageMixin, self)
-        return sup.formfield_for_dbfield(db_field, **kwargs)
+        return sup.formfield_for_dbfield(db_field, request, **kwargs)


### PR DESCRIPTION
This (hopefully) fixes a bug that appears when calling `super().formfield_for_dbfield(db_field, request, **kwargs)` from another app/your code. `request` was added as argument in Django in 2015: https://github.com/django/django/commit/dbb0df2a0ec5bee80bee336fc81408efb30b7e47

django-modeltranslation had the same issue: https://github.com/deschler/django-modeltranslation/issues/510

It looks like a bug in sorl-thumbnail, not in django-modeltranslation: https://github.com/deschler/django-modeltranslation/issues/514

What do you think when this can be released?

---

My installed versions: Django 1.11.24, django-modeltranslation 0.13.3, sorl-thumbnail 12.5.0

My traceback that motivated me to open this PR:

```
File ".venv/lib/python3.7/site-packages/django/core/handlers/exception.py" in inner
41. response = get_response(request)

File ".venv/lib/python3.7/site-packages/django/core/handlers/base.py" in _legacy_get_response
249. response = self._get_response(request)

File ".venv/lib/python3.7/site-packages/django/core/handlers/base.py" in _get_response
187. response = self.process_exception_by_middleware(e, request)

File ".venv/lib/python3.7/site-packages/django/core/handlers/base.py" in _get_response
185. response = wrapped_callback(request, *callback_args, **callback_kwargs)

File ".venv/lib/python3.7/site-packages/django/contrib/admin/options.py" in wrapper
552. return self.admin_site.admin_view(view)(*args, **kwargs)

File ".venv/lib/python3.7/site-packages/django/utils/decorators.py" in _wrapped_view
149. response = view_func(request, *args, **kwargs)

File ".venv/lib/python3.7/site-packages/django/views/decorators/cache.py" in _wrapped_view_func
57. response = view_func(request, *args, **kwargs)

File ".venv/lib/python3.7/site-packages/django/contrib/admin/sites.py" in inner
224. return view(request, *args, **kwargs)

File ".venv/lib/python3.7/site-packages/django/contrib/admin/options.py" in change_view
1512. return self.changeform_view(request, object_id, form_url, extra_context)

File ".venv/lib/python3.7/site-packages/django/utils/decorators.py" in _wrapper
67. return bound_func(*args, **kwargs)

File ".venv/lib/python3.7/site-packages/django/utils/decorators.py" in _wrapped_view
149. response = view_func(request, *args, **kwargs)

File ".venv/lib/python3.7/site-packages/django/utils/decorators.py" in bound_func
63. return func.__get__(self, type(self))(*args2, **kwargs2)

File ".venv/lib/python3.7/site-packages/django/contrib/admin/options.py" in changeform_view
1409. return self._changeform_view(request, object_id, form_url, extra_context)

File ".venv/lib/python3.7/site-packages/django/contrib/admin/options.py" in _changeform_view
1438. ModelForm = self.get_form(request, obj)

File ".venv/lib/python3.7/site-packages/modeltranslation/admin.py" in get_form
317. return super(TranslationAdmin, self).get_form(request, obj, **kwargs)

File ".venv/lib/python3.7/site-packages/django/contrib/admin/options.py" in get_form
616. fields = flatten_fieldsets(self.get_fieldsets(request, obj))

File ".venv/lib/python3.7/site-packages/modeltranslation/admin.py" in get_fieldsets
322. request, self.get_form(request, obj, fields=None), obj))

File ".venv/lib/python3.7/site-packages/modeltranslation/admin.py" in get_form
317. return super(TranslationAdmin, self).get_form(request, obj, **kwargs)

File ".venv/lib/python3.7/site-packages/django/contrib/admin/options.py" in get_form
648. return modelform_factory(self.model, **defaults)

File ".venv/lib/python3.7/site-packages/django/forms/models.py" in modelform_factory
563. return type(form)(class_name, (form,), form_class_attrs)

File ".venv/lib/python3.7/site-packages/django/forms/models.py" in __new__
266. apply_limit_choices_to=False,

File ".venv/lib/python3.7/site-packages/django/forms/models.py" in fields_for_model
186. formfield = formfield_callback(f, **kwargs)

File ".venv/lib/python3.7/site-packages/sorl/thumbnail/admin/current.py" in formfield_for_dbfield
64. return sup.formfield_for_dbfield(db_field, **kwargs)

File ".venv/lib/python3.7/site-packages/modeltranslation/admin.py" in formfield_for_dbfield
42. self.patch_translation_field(db_field, field, request, **kwargs)

File ".venv/lib/python3.7/site-packages/modeltranslation/admin.py" in patch_translation_field
60. orig_field, request, **kwargs

Exception Value: formfield_for_dbfield() takes 2 positional arguments but 3 were given
```