### PR TITLE
Support Django 3.0+

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -75,6 +75,32 @@ matrix:
     - python: "3.7"
       env: TOXENV=py37-django22-dbm
 
+    - python: "3.7"
+      env: TOXENV=py37-django30-pil
+    - python: "3.7"
+      env: TOXENV=py37-django30-imagemagick
+    - python: "3.7"
+      env: TOXENV=py37-django30-graphicsmagick
+    - python: "3.7"
+      env: TOXENV=py37-django30-redis
+    - python: "3.7"
+      env: TOXENV=py37-django30-wand
+    - python: "3.7"
+      env: TOXENV=py37-django30-dbm
+
+    - python: "3.8"
+      env: TOXENV=py38-django30-pil
+    - python: "3.8"
+      env: TOXENV=py38-django30-imagemagick
+    - python: "3.8"
+      env: TOXENV=py38-django30-graphicsmagick
+    - python: "3.8"
+      env: TOXENV=py38-django30-redis
+    - python: "3.8"
+      env: TOXENV=py38-django30-wand
+    - python: "3.8"
+      env: TOXENV=py38-django30-dbm
+
 addons:
   apt:
     packages:

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,19 +3,6 @@ dist: xenial
 
 matrix:
   include:
-    - python: "2.7"
-      env: TOXENV=py27-django111-pil
-    - python: "2.7"
-      env: TOXENV=py27-django111-imagemagick
-    - python: "2.7"
-      env: TOXENV=py27-django111-graphicsmagick
-    - python: "2.7"
-      env: TOXENV=py27-django111-redis
-    - python: "2.7"
-      env: TOXENV=py27-django111-wand
-    - python: "2.7"
-      env: TOXENV=py27-django111-dbm
-
     - python: "3.6"
       env: TOXENV=py36-django111-pil
     - python: "3.6"
@@ -56,6 +43,9 @@ matrix:
       env: TOXENV=py36-django21-wand
     - python: "3.6"
       env: TOXENV=py36-django21-dbm
+
+    - python: "3.6"
+      env: TOXENV=py36-django30-pil
 
     - python: "3.7"
       env: TOXENV=py37-django20-pil

--- a/README.rst
+++ b/README.rst
@@ -5,7 +5,7 @@ Thumbnails for Django.
 Features at a glance
 ====================
 
-- Support for Django 1.11, 2.0, 2.1, and 2.2 following the `Django supported versions policy`_
+- Support for Django 1.11, 2.0, 2.1, 2.2 and 3.0 following the `Django supported versions policy`_
 - Python 3 support
 - Storage support
 - Pluggable Engine support for `Pillow`_, `ImageMagick`_, `PIL`_, `Wand`_, `pgmagick`_, and `vipsthumbnail`_

--- a/docs/template.rst
+++ b/docs/template.rst
@@ -42,7 +42,7 @@ Source can be an ImageField, FileField, a file name (assuming default_storage),
 a url. What we need to know is name and storage, see how ImageFile figures
 these things out::
 
-    from django.utils.encoding import force_text
+    from django.utils.encoding import force_str
 
     class ImageFile(BaseImageFile):
         _size = None
@@ -54,7 +54,7 @@ these things out::
             if hasattr(file_, 'name'):
                 self.name = file_.name
             else:
-                self.name = force_text(file_)
+                self.name = force_str(file_)
             # figure out storage
             if storage is not None:
                 self.storage = storage

--- a/setup.py
+++ b/setup.py
@@ -33,7 +33,6 @@ setup(
         'License :: OSI Approved :: BSD License',
         'Operating System :: OS Independent',
         'Programming Language :: Python',
-        'Programming Language :: Python :: 2.7',
         'Programming Language :: Python :: 3.4',
         'Programming Language :: Python :: 3.5',
         'Programming Language :: Python :: 3.6',

--- a/setup.py
+++ b/setup.py
@@ -38,6 +38,7 @@ setup(
         'Programming Language :: Python :: 3.5',
         'Programming Language :: Python :: 3.6',
         'Programming Language :: Python :: 3.7',
+        'Programming Language :: Python :: 3.8',
         'Topic :: Internet :: WWW/HTTP :: Dynamic Content',
         'Topic :: Multimedia :: Graphics',
         'Framework :: Django',
@@ -45,6 +46,7 @@ setup(
         'Framework :: Django :: 2.0',
         'Framework :: Django :: 2.1',
         'Framework :: Django :: 2.2',
+        'Framework :: Django :: 3.0',
     ],
     cmdclass={"test": TestCommand},
 )

--- a/sorl/thumbnail/base.py
+++ b/sorl/thumbnail/base.py
@@ -4,8 +4,6 @@ import logging
 import os
 import re
 
-from six import string_types
-
 from sorl.thumbnail.conf import settings, defaults as default_settings
 from sorl.thumbnail.helpers import tokey, serialize
 from sorl.thumbnail.images import ImageFile, DummyImageFile
@@ -179,7 +177,7 @@ class ThumbnailBackend(object):
         for resolution in settings.THUMBNAIL_ALTERNATIVE_RESOLUTIONS:
             resolution_geometry = (int(geometry[0] * resolution), int(geometry[1] * resolution))
             resolution_options = options.copy()
-            if 'crop' in options and isinstance(options['crop'], string_types):
+            if 'crop' in options and isinstance(options['crop'], str):
                 crop = options['crop'].split(" ")
                 for i in range(len(crop)):
                     s = re.match(r"(\d+)px", crop[i])

--- a/sorl/thumbnail/base.py
+++ b/sorl/thumbnail/base.py
@@ -4,7 +4,7 @@ import logging
 import os
 import re
 
-from django.utils.six import string_types
+from six import string_types
 
 from sorl.thumbnail.conf import settings, defaults as default_settings
 from sorl.thumbnail.helpers import tokey, serialize

--- a/sorl/thumbnail/helpers.py
+++ b/sorl/thumbnail/helpers.py
@@ -6,7 +6,7 @@ import math
 from importlib import import_module
 
 from django.core.exceptions import ImproperlyConfigured
-from django.utils.encoding import force_text
+from django.utils.encoding import force_str
 from sorl.thumbnail.compat import encode
 
 
@@ -43,7 +43,7 @@ def tokey(*args):
     """
     Computes a unique key from arguments given.
     """
-    salt = '||'.join([force_text(arg) for arg in args])
+    salt = '||'.join([force_str(arg) for arg in args])
     hash_ = hashlib.md5(encode(salt))
     return hash_.hexdigest()
 

--- a/sorl/thumbnail/images.py
+++ b/sorl/thumbnail/images.py
@@ -7,9 +7,8 @@ import re
 
 from django.core.files.base import File, ContentFile
 from django.core.files.storage import Storage  # , default_storage
-from django.utils.encoding import force_text
+from django.utils.encoding import force_str
 from django.utils.functional import LazyObject, empty
-from six import python_2_unicode_compatible
 from sorl.thumbnail import default
 from sorl.thumbnail.conf import settings
 from sorl.thumbnail.compat import (urlopen, urlparse, urlsplit,
@@ -77,7 +76,6 @@ class BaseImageFile(object):
     src = url
 
 
-@python_2_unicode_compatible
 class ImageFile(BaseImageFile):
     _size = None
 
@@ -89,7 +87,7 @@ class ImageFile(BaseImageFile):
         if hasattr(file_, 'name'):
             self.name = file_.name
         else:
-            self.name = force_text(file_)
+            self.name = force_str(file_)
 
         # TODO: Add a customizable naming method as a signal
 

--- a/sorl/thumbnail/images.py
+++ b/sorl/thumbnail/images.py
@@ -7,8 +7,9 @@ import re
 
 from django.core.files.base import File, ContentFile
 from django.core.files.storage import Storage  # , default_storage
-from django.utils.encoding import force_text, python_2_unicode_compatible
+from django.utils.encoding import force_text
 from django.utils.functional import LazyObject, empty
+from six import python_2_unicode_compatible
 from sorl.thumbnail import default
 from sorl.thumbnail.conf import settings
 from sorl.thumbnail.compat import (urlopen, urlparse, urlsplit,

--- a/sorl/thumbnail/models.py
+++ b/sorl/thumbnail/models.py
@@ -1,5 +1,5 @@
+from six import python_2_unicode_compatible
 from django.db import models
-from django.utils.encoding import python_2_unicode_compatible
 
 from sorl.thumbnail.conf import settings
 

--- a/sorl/thumbnail/models.py
+++ b/sorl/thumbnail/models.py
@@ -1,10 +1,8 @@
-from six import python_2_unicode_compatible
 from django.db import models
 
 from sorl.thumbnail.conf import settings
 
 
-@python_2_unicode_compatible
 class KVStore(models.Model):
     key = models.CharField(
         max_length=200, primary_key=True,

--- a/sorl/thumbnail/parsers.py
+++ b/sorl/thumbnail/parsers.py
@@ -1,8 +1,6 @@
 # coding=utf-8
 import re
 
-import six
-
 from sorl.thumbnail.helpers import ThumbnailError, toint
 
 
@@ -100,7 +98,7 @@ def parse_cropbox(cropbox):
     """
     Returns x, y, x2, y2 tuple for cropping.
     """
-    if isinstance(cropbox, six.text_type):
+    if isinstance(cropbox, str):
         return tuple([int(x.strip()) for x in cropbox.split(',')])
     else:
         return tuple(cropbox)

--- a/sorl/thumbnail/parsers.py
+++ b/sorl/thumbnail/parsers.py
@@ -1,7 +1,7 @@
 # coding=utf-8
 import re
 
-from django.utils import six
+import six
 
 from sorl.thumbnail.helpers import ThumbnailError, toint
 

--- a/sorl/thumbnail/templatetags/thumbnail.py
+++ b/sorl/thumbnail/templatetags/thumbnail.py
@@ -10,8 +10,9 @@ from functools import wraps
 
 from django.template import Library, Node, NodeList, TemplateSyntaxError
 from django.utils.encoding import smart_str
-from django.utils.six import text_type
 from django.conf import settings
+
+from six import text_type
 
 from sorl.thumbnail.conf import settings as sorl_settings
 from sorl.thumbnail import default

--- a/sorl/thumbnail/templatetags/thumbnail.py
+++ b/sorl/thumbnail/templatetags/thumbnail.py
@@ -12,8 +12,6 @@ from django.template import Library, Node, NodeList, TemplateSyntaxError
 from django.utils.encoding import smart_str
 from django.conf import settings
 
-from six import text_type
-
 from sorl.thumbnail.conf import settings as sorl_settings
 from sorl.thumbnail import default
 from sorl.thumbnail.images import ImageFile, DummyImageFile
@@ -130,7 +128,7 @@ class ThumbnailNode(ThumbnailNodeBase):
         options = {}
         for key, expr in self.options:
             noresolve = {'True': True, 'False': False, 'None': None}
-            value = noresolve.get(text_type(expr), expr.resolve(context))
+            value = noresolve.get(str(expr), expr.resolve(context))
             if key == 'options':
                 options.update(value)
             else:

--- a/tests/thumbnail_tests/test_admin.py
+++ b/tests/thumbnail_tests/test_admin.py
@@ -1,5 +1,4 @@
 from django.test import SimpleTestCase
-from django.test.utils import override_settings
 
 from sorl.thumbnail.admin.current import AdminImageWidget
 

--- a/tests/thumbnail_tests/test_backends.py
+++ b/tests/thumbnail_tests/test_backends.py
@@ -6,7 +6,7 @@ import unittest
 from PIL import Image
 
 import pytest
-from django.utils.six import StringIO
+from six import StringIO
 from django.test import TestCase
 from django.test.utils import override_settings
 

--- a/tests/thumbnail_tests/test_backends.py
+++ b/tests/thumbnail_tests/test_backends.py
@@ -1,4 +1,5 @@
 # -*- coding: utf-8 -*-
+from io import StringIO
 import os
 import sys
 import shutil
@@ -6,7 +7,6 @@ import unittest
 from PIL import Image
 
 import pytest
-from six import StringIO
 from django.test import TestCase
 from django.test.utils import override_settings
 

--- a/tests/thumbnail_tests/test_commands.py
+++ b/tests/thumbnail_tests/test_commands.py
@@ -1,9 +1,9 @@
 # -*- coding: utf-8 -*-
+from io import StringIO
 import os
 
 import pytest
 from django.core import management
-from six import StringIO
 
 from sorl.thumbnail.conf import settings
 from .models import Item

--- a/tests/thumbnail_tests/test_commands.py
+++ b/tests/thumbnail_tests/test_commands.py
@@ -2,8 +2,8 @@
 import os
 
 import pytest
-from django.utils.six import StringIO
 from django.core import management
+from six import StringIO
 
 from sorl.thumbnail.conf import settings
 from .models import Item

--- a/tests/thumbnail_tests/test_engines.py
+++ b/tests/thumbnail_tests/test_engines.py
@@ -241,7 +241,6 @@ class SimpleTestCase(BaseTestCase):
         self.assertEqual(t.x, 100)
         self.assertEqual(t.y, 100)
 
-
     def test_falsey_file_argument(self):
         with self.assertRaises(ValueError):
             self.BACKEND.get_thumbnail('', '100x100')

--- a/tox.ini
+++ b/tox.ini
@@ -2,7 +2,7 @@
 
 [tox]
 skipsdist = True
-envlist = {py27,py34,py35,py36}-django111-{pil,imagemagick,graphicsmagick,redis,dynamodb,wand,pgmagick,dbm,vipsthumbnail}
+envlist = {py34,py35,py36}-django111-{pil,imagemagick,graphicsmagick,redis,dynamodb,wand,pgmagick,dbm,vipsthumbnail}
           {py34,py35,py36,py37}-django20-{pil,imagemagick,graphicsmagick,redis,dynamodb,wand,pgmagick,dbm,vipsthumbnail}
           {py35,py36,py37}-django21-{pil,imagemagick,graphicsmagick,redis,dynamodb,wand,pgmagick,dbm,vipsthumbnail}
           {py35,py36,py37}-django22-{pil,imagemagick,graphicsmagick,redis,dynamodb,wand,pgmagick,dbm,vipsthumbnail}

--- a/tox.ini
+++ b/tox.ini
@@ -6,6 +6,7 @@ envlist = {py27,py34,py35,py36}-django111-{pil,imagemagick,graphicsmagick,redis,
           {py34,py35,py36,py37}-django20-{pil,imagemagick,graphicsmagick,redis,dynamodb,wand,pgmagick,dbm,vipsthumbnail}
           {py35,py36,py37}-django21-{pil,imagemagick,graphicsmagick,redis,dynamodb,wand,pgmagick,dbm,vipsthumbnail}
           {py35,py36,py37}-django22-{pil,imagemagick,graphicsmagick,redis,dynamodb,wand,pgmagick,dbm,vipsthumbnail}
+          {py36,py37,py38}-django30-{pil,imagemagick,graphicsmagick,redis,dynamodb,wand,pgmagick,dbm,vipsthumbnail}
 
 [testenv]
 changedir = {toxinidir}/tests
@@ -22,6 +23,7 @@ deps = pytest
        django20: Django>=2.0a1,<2.1
        django21: Django>=2.1a1,<2.2
        django22: Django>=2.2a1,<3.0
+       django30: Django>=3.0a1,<3.1
 
 setenv = PYTHONPATH = {toxinidir}:{toxinidir}
          pil: DJANGO_SETTINGS_MODULE=tests.settings.pil


### PR DESCRIPTION
`django.utils.six` and some aliases were removed from Django in 3.0. 