### PR TITLE
Add Django 3 support

### DIFF
--- a/docs/template.rst
+++ b/docs/template.rst
@@ -42,7 +42,7 @@ Source can be an ImageField, FileField, a file name (assuming default_storage),
 a url. What we need to know is name and storage, see how ImageFile figures
 these things out::
 
-    from django.utils.encoding import force_text
+    from django.utils.encoding import force_str
 
     class ImageFile(BaseImageFile):
         _size = None
@@ -54,7 +54,7 @@ these things out::
             if hasattr(file_, 'name'):
                 self.name = file_.name
             else:
-                self.name = force_text(file_)
+                self.name = force_str(file_)
             # figure out storage
             if storage is not None:
                 self.storage = storage

--- a/sorl/thumbnail/helpers.py
+++ b/sorl/thumbnail/helpers.py
@@ -6,7 +6,7 @@ import math
 from importlib import import_module
 
 from django.core.exceptions import ImproperlyConfigured
-from django.utils.encoding import force_text
+from django.utils.encoding import force_str
 from sorl.thumbnail.compat import encode
 
 
@@ -43,7 +43,7 @@ def tokey(*args):
     """
     Computes a unique key from arguments given.
     """
-    salt = '||'.join([force_text(arg) for arg in args])
+    salt = '||'.join([force_str(arg) for arg in args])
     hash_ = hashlib.md5(encode(salt))
     return hash_.hexdigest()
 

--- a/sorl/thumbnail/images.py
+++ b/sorl/thumbnail/images.py
@@ -7,8 +7,9 @@ import re
 
 from django.core.files.base import File, ContentFile
 from django.core.files.storage import Storage  # , default_storage
-from django.utils.encoding import force_text, python_2_unicode_compatible
+from django.utils.encoding import force_text
 from django.utils.functional import LazyObject, empty
+from six import python_2_unicode_compatible
 from sorl.thumbnail import default
 from sorl.thumbnail.conf import settings
 from sorl.thumbnail.compat import (urlopen, urlparse, urlsplit,

--- a/sorl/thumbnail/models.py
+++ b/sorl/thumbnail/models.py
@@ -1,5 +1,5 @@
+from six import python_2_unicode_compatible
 from django.db import models
-from django.utils.encoding import python_2_unicode_compatible
 
 from sorl.thumbnail.conf import settings
 


### PR DESCRIPTION
These are some of the changes required by for compatibility with Django 3.0 ( #601 )

I don't know my way around the project so there are some tasks left to do.

- Support for python 2.7, and versions of Django << 2.0 have to be dropped.
- six has to be added as a dev
- tests for Django << 2.0 & Python << 3 have to be removed and replaced with tests for Django 3.0.


https://docs.djangoproject.com/en/3.0/releases/3.0/#features-deprecated-in-3-0
https://docs.djangoproject.com/en/3.0/releases/3.0/#removed-private-python-2-compatibility-apis