### PR TITLE
This is no longer a universal wheel

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,8 +1,5 @@
-[wheel]
-universal = 1
-
 [bdist_wheel]
-universal = 1
+universal = 0
 
 ;; flake8 analyzes and detect varios errors in the source code.
 


### PR DESCRIPTION
If you run `python setup.py bdist_wheel`, you will get py2-py3 .whl files.

I think it's become a Python 3-only package since #600 as the PyPi meta data was updated to say so.

See: https://packaging.python.org/guides/distributing-packages-using-setuptools/#universal-wheels