### PR TITLE
Re-add Python 3.4 and 3.5 definitions

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -2,6 +2,14 @@
 Changelog
 =========
 
+12.6.1
+======
+
+* Deprecate explicit support for Python 3.4 and 3.5 in order to simplify the test matrix #610
+* Add requirement for ``setuptools_scm`` to automatically resolve version from git tags #610
+* Removed property ``thumbnail.__version__`` #610
+
+
 12.6.0
 ======
 

--- a/setup.py
+++ b/setup.py
@@ -22,7 +22,7 @@ setup(
     url='https://github.com/jazzband/sorl-thumbnail',
     packages=find_packages(exclude=['tests', 'tests.*']),
     platforms='any',
-    python_requires='>=3.6',
+    python_requires='>=3.4',
     zip_safe=False,
     classifiers=[
         'Development Status :: 2 - Pre-Alpha',
@@ -31,6 +31,8 @@ setup(
         'License :: OSI Approved :: BSD License',
         'Operating System :: OS Independent',
         'Programming Language :: Python',
+        'Programming Language :: Python :: 3.4',
+        'Programming Language :: Python :: 3.5',
         'Programming Language :: Python :: 3.6',
         'Programming Language :: Python :: 3.7',
         'Programming Language :: Python :: 3.8',


### PR DESCRIPTION
Suggesting to merge this and tag 12.6.1

CC: @aleksihakli @camilonova @jezdez 