### PR TITLE
fix ratio when image has an exif orientation

### DIFF
--- a/sorl/thumbnail/engines/base.py
+++ b/sorl/thumbnail/engines/base.py
@@ -79,6 +79,8 @@ class EngineBase(object):
         """
         upscale = options['upscale']
         x_image, y_image = map(float, self.get_image_size(image))
+        if self.get_exif_orientation(image) in [5, 6, 7, 8]:
+            x_image, y_image = y_image, x_image
         factor = self._calculate_scaling_factor(x_image, y_image, geometry, options)
 
         if factor < 1 or upscale:
@@ -193,6 +195,12 @@ class EngineBase(object):
         Checks if the supplied raw data is valid image data
         """
         raise NotImplementedError()
+
+    def get_exif_orientation(self, image):
+        """
+        Returns the image exif orientation
+        """
+        return None
 
     def _orientation(self, image):
         """

--- a/sorl/thumbnail/engines/base.py
+++ b/sorl/thumbnail/engines/base.py
@@ -1,14 +1,10 @@
 # coding=utf-8
 from __future__ import division
 
-import logging
-
 from sorl.thumbnail.conf import settings
 from sorl.thumbnail.helpers import toint
 from sorl.thumbnail.parsers import parse_crop
 from sorl.thumbnail.parsers import parse_cropbox
-
-logger = logging.getLogger(__name__)
 
 
 class EngineBase(object):
@@ -204,15 +200,6 @@ class EngineBase(object):
         Checks if the supplied raw data is valid image data
         """
         raise NotImplementedError()
-
-    def get_exif_orientation(self, image):
-        """
-        Returns the image exif orientation
-        """
-        logger.warning("'{}' engine doesn't implement get_exif_orientation'".format(
-            settings.THUMBNAIL_ENGINE
-        ))
-        return None
 
     def _orientation(self, image):
         """

--- a/sorl/thumbnail/engines/base.py
+++ b/sorl/thumbnail/engines/base.py
@@ -83,7 +83,7 @@ class EngineBase(object):
         """
         upscale = options['upscale']
         x_image, y_image = map(float, self.get_image_size(image))
-        if settings.THUMBNAIL_ORIENTATION and self.flip_dimensions(image):
+        if self.flip_dimensions(image):
             x_image, y_image = y_image, x_image
         factor = self._calculate_scaling_factor(x_image, y_image, geometry, options)
 
@@ -174,7 +174,7 @@ class EngineBase(object):
 
         ratio = float(x) / y
 
-        if settings.THUMBNAIL_ORIENTATION and self.flip_dimensions(image):
+        if self.flip_dimensions(image):
             ratio = 1.0 / ratio
 
         return ratio

--- a/sorl/thumbnail/engines/base.py
+++ b/sorl/thumbnail/engines/base.py
@@ -10,6 +10,7 @@ from sorl.thumbnail.parsers import parse_cropbox
 
 logger = logging.getLogger(__name__)
 
+
 class EngineBase(object):
     """
     ABC for Thumbnail engines, methods are static
@@ -170,9 +171,9 @@ class EngineBase(object):
             y = y2 - y
         else:
             x, y = self.get_image_size(image)
-        
+
         ratio = float(x) / y
-        
+
         if settings.THUMBNAIL_ORIENTATION:
             orientation = self.get_exif_orientation(image)
             if orientation in [5, 6, 7, 8]:

--- a/sorl/thumbnail/engines/base.py
+++ b/sorl/thumbnail/engines/base.py
@@ -83,7 +83,7 @@ class EngineBase(object):
         """
         upscale = options['upscale']
         x_image, y_image = map(float, self.get_image_size(image))
-        if settings.THUMBNAIL_ORIENTATION and self.get_exif_orientation(image) in [5, 6, 7, 8]:
+        if settings.THUMBNAIL_ORIENTATION and self.flip_dimensions(image):
             x_image, y_image = y_image, x_image
         factor = self._calculate_scaling_factor(x_image, y_image, geometry, options)
 
@@ -174,10 +174,8 @@ class EngineBase(object):
 
         ratio = float(x) / y
 
-        if settings.THUMBNAIL_ORIENTATION:
-            orientation = self.get_exif_orientation(image)
-            if orientation in [5, 6, 7, 8]:
-                ratio = 1.0 / ratio
+        if settings.THUMBNAIL_ORIENTATION and self.flip_dimensions(image):
+            ratio = 1.0 / ratio
 
         return ratio
 

--- a/sorl/thumbnail/engines/base.py
+++ b/sorl/thumbnail/engines/base.py
@@ -1,11 +1,14 @@
 # coding=utf-8
 from __future__ import division
 
+import logging
+
 from sorl.thumbnail.conf import settings
 from sorl.thumbnail.helpers import toint
 from sorl.thumbnail.parsers import parse_crop
 from sorl.thumbnail.parsers import parse_cropbox
 
+logger = logging.getLogger(__name__)
 
 class EngineBase(object):
     """
@@ -79,7 +82,7 @@ class EngineBase(object):
         """
         upscale = options['upscale']
         x_image, y_image = map(float, self.get_image_size(image))
-        if self.get_exif_orientation(image) in [5, 6, 7, 8]:
+        if settings.THUMBNAIL_ORIENTATION and self.get_exif_orientation(image) in [5, 6, 7, 8]:
             x_image, y_image = y_image, x_image
         factor = self._calculate_scaling_factor(x_image, y_image, geometry, options)
 
@@ -167,8 +170,15 @@ class EngineBase(object):
             y = y2 - y
         else:
             x, y = self.get_image_size(image)
+        
+        ratio = float(x) / y
+        
+        if settings.THUMBNAIL_ORIENTATION:
+            orientation = self.get_exif_orientation(image)
+            if orientation in [5, 6, 7, 8]:
+                ratio = 1.0 / ratio
 
-        return float(x) / y
+        return ratio
 
     def get_image_info(self, image):
         """
@@ -200,6 +210,9 @@ class EngineBase(object):
         """
         Returns the image exif orientation
         """
+        logger.warning("'{}' engine doesn't implement get_exif_orientation'".format(
+            settings.THUMBNAIL_ENGINE
+        ))
         return None
 
     def _orientation(self, image):

--- a/sorl/thumbnail/engines/convert_engine.py
+++ b/sorl/thumbnail/engines/convert_engine.py
@@ -9,7 +9,6 @@ from django.utils.encoding import smart_str
 from django.core.files.temp import NamedTemporaryFile
 
 from sorl.thumbnail.base import EXTENSIONS
-from sorl.thumbnail.compat import b
 from sorl.thumbnail.conf import settings
 from sorl.thumbnail.engines.base import EngineBase
 
@@ -112,7 +111,7 @@ class Engine(EngineBase):
         if orientation in [5, 6, 7, 8]:
             ratio = 1.0 / ratio
         return ratio
-    
+
     def get_exif_orientation(self, image):
         args = settings.THUMBNAIL_IDENTIFY.split()
         args.extend(['-format', '%[exif:orientation]', image['source']])
@@ -121,7 +120,7 @@ class Engine(EngineBase):
         result = p.stdout.read().strip()
         if result and result != 'unknown':
             return int(result)
-        else: 
+        else:
             return None
 
     def _orientation(self, image):

--- a/sorl/thumbnail/engines/convert_engine.py
+++ b/sorl/thumbnail/engines/convert_engine.py
@@ -105,13 +105,6 @@ class Engine(EngineBase):
             retcode = p.wait()
         return retcode == 0
 
-    def get_image_ratio(self, image, options):
-        ratio = super(Engine, self).get_image_ratio(image, options)
-        orientation = self.get_exif_orientation(image)
-        if orientation in [5, 6, 7, 8]:
-            ratio = 1.0 / ratio
-        return ratio
-
     def get_exif_orientation(self, image):
         args = settings.THUMBNAIL_IDENTIFY.split()
         args.extend(['-format', '%[exif:orientation]', image['source']])

--- a/sorl/thumbnail/engines/convert_engine.py
+++ b/sorl/thumbnail/engines/convert_engine.py
@@ -105,7 +105,7 @@ class Engine(EngineBase):
             retcode = p.wait()
         return retcode == 0
 
-    def get_exif_orientation(self, image):
+    def _get_exif_orientation(self, image):
         args = settings.THUMBNAIL_IDENTIFY.split()
         args.extend(['-format', '%[exif:orientation]', image['source']])
         p = subprocess.Popen(args, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
@@ -121,7 +121,7 @@ class Engine(EngineBase):
         # XXX need to get the dimensions right after a transpose.
 
         if settings.THUMBNAIL_CONVERT.endswith('gm convert'):
-            orientation = self.get_exif_orientation(image)
+            orientation = self._get_exif_orientation(image)
             if orientation:
                 options = image['options']
                 if orientation == 2:
@@ -147,11 +147,8 @@ class Engine(EngineBase):
         return image
 
     def _flip_dimensions(self, image):
-        if settings.THUMBNAIL_CONVERT.endswith('gm convert'):
-            orientation = self.get_exif_orientation(image)
-            return orientation and orientation in [5, 6, 7, 8]
-        else:
-            return False
+        orientation = self._get_exif_orientation(image)
+        return orientation and orientation in [5, 6, 7, 8]
 
     def _colorspace(self, image, colorspace):
         """

--- a/sorl/thumbnail/engines/pgmagick_engine.py
+++ b/sorl/thumbnail/engines/pgmagick_engine.py
@@ -56,7 +56,7 @@ class Engine(EngineBase):
 
         return image
 
-    def flip_dimensions(self, image):
+    def _flip_dimensions(self, image):
         return image.orientation() in [
             OrientationType.LeftTopOrientation,
             OrientationType.RightTopOrientation,

--- a/sorl/thumbnail/engines/pil_engine.py
+++ b/sorl/thumbnail/engines/pil_engine.py
@@ -97,6 +97,9 @@ class Engine(EngineBase):
 
         return self._colorspace(image, colorspace, format)
 
+    def _cropbox(self, image, x, y, x2, y2):
+        return image.crop((x, y, x2, y2))
+
     def _get_exif_orientation(self, image):
         try:
             exif = image._getexif()
@@ -107,9 +110,6 @@ class Engine(EngineBase):
             return exif.get(EXIF_ORIENTATION)
         else:
             return None
-
-    def _cropbox(self, image, x, y, x2, y2):
-        return image.crop((x, y, x2, y2))
 
     def _orientation(self, image):
         orientation = self._get_exif_orientation(image)

--- a/sorl/thumbnail/engines/pil_engine.py
+++ b/sorl/thumbnail/engines/pil_engine.py
@@ -115,7 +115,6 @@ class Engine(EngineBase):
         orientation = self._get_exif_orientation(image)
 
         if orientation:
-
             if orientation == 2:
                 image = image.transpose(Image.FLIP_LEFT_RIGHT)
             elif orientation == 3:

--- a/sorl/thumbnail/engines/pil_engine.py
+++ b/sorl/thumbnail/engines/pil_engine.py
@@ -97,7 +97,7 @@ class Engine(EngineBase):
 
         return self._colorspace(image, colorspace, format)
 
-    def get_exif_orientation(self, image):
+    def _get_exif_orientation(self, image):
         try:
             exif = image._getexif()
         except Exception:
@@ -112,7 +112,7 @@ class Engine(EngineBase):
         return image.crop((x, y, x2, y2))
 
     def _orientation(self, image):
-        orientation = self.get_exif_orientation(image)
+        orientation = self._get_exif_orientation(image)
 
         if orientation:
 
@@ -134,12 +134,8 @@ class Engine(EngineBase):
         return image
 
     def _flip_dimensions(self, image):
-        orientation = self.get_exif_orientation(image)
-
-        if orientation:
-            return orientation in [5, 6, 7, 8]
-
-        return False
+        orientation = self._get_exif_orientation(image)
+        return orientation and orientation in [5, 6, 7, 8]
 
     def _colorspace(self, image, colorspace, format):
         if colorspace == 'RGB':

--- a/sorl/thumbnail/engines/pil_engine.py
+++ b/sorl/thumbnail/engines/pil_engine.py
@@ -97,17 +97,24 @@ class Engine(EngineBase):
 
         return self._colorspace(image, colorspace, format)
 
-    def _cropbox(self, image, x, y, x2, y2):
-        return image.crop((x, y, x2, y2))
-
-    def _orientation(self, image):
+    def get_exif_orientation(self, image):
         try:
             exif = image._getexif()
         except Exception:
             exif = None
 
         if exif:
-            orientation = exif.get(EXIF_ORIENTATION)
+            return exif.get(EXIF_ORIENTATION)
+        else:
+            return None
+
+    def _cropbox(self, image, x, y, x2, y2):
+        return image.crop((x, y, x2, y2))
+
+    def _orientation(self, image):
+        orientation = self.get_exif_orientation(image)
+
+        if orientation:
 
             if orientation == 2:
                 image = image.transpose(Image.FLIP_LEFT_RIGHT)
@@ -127,13 +134,9 @@ class Engine(EngineBase):
         return image
 
     def _flip_dimensions(self, image):
-        try:
-            exif = image._getexif()
-        except (AttributeError, IOError, KeyError, IndexError):
-            exif = None
+        orientation = self.get_exif_orientation(image)
 
-        if exif:
-            orientation = exif.get(0x0112)
+        if orientation:
             return orientation in [5, 6, 7, 8]
 
         return False

--- a/tests/thumbnail_tests/test_engines.py
+++ b/tests/thumbnail_tests/test_engines.py
@@ -355,7 +355,7 @@ class CropTestCase(BaseTestCase):
         self.assertEqual(im.size[1], 32)
 
     @unittest.skipIf(
-        'pil_engine' not in settings.THUMBNAIL_ENGINE,
+        'pil_engine' not in settings.THUMBNAIL_ENGINE and 'convert_engine' not in settings.THUMBNAIL_ENGINE,
         'the other engines fail this test',
     )
     def test_image_with_orientation(self):

--- a/tests/thumbnail_tests/test_engines.py
+++ b/tests/thumbnail_tests/test_engines.py
@@ -354,10 +354,6 @@ class CropTestCase(BaseTestCase):
         self.assertEqual(im.size[0], 32)
         self.assertEqual(im.size[1], 32)
 
-    @unittest.skipIf(
-        'pil_engine' not in settings.THUMBNAIL_ENGINE and 'convert_engine' not in settings.THUMBNAIL_ENGINE,
-        'the other engines fail this test',
-    )
     def test_image_with_orientation(self):
         name = 'data/aspect_test.jpg'
         item, _ = Item.objects.get_or_create(image=name)


### PR DESCRIPTION
_(edited after final commit)_

Trying to fix #618 by taking inspiration on #495. 

* adapt `get_image_ratio` and `scale` stages to take the orientation into account
* use the *flip_dimensions* return to decide whether there is an orientation or not
* add a *_get_exif_orientation* to `convert_engine` and `pil_engine` 

The related test is not skipped anymore, for all the engines.
