### PR TITLE
Using more resilient _get_exif_orientation logic in convert engine

### DIFF
--- a/sorl/thumbnail/engines/convert_engine.py
+++ b/sorl/thumbnail/engines/convert_engine.py
@@ -110,9 +110,9 @@ class Engine(EngineBase):
         p = subprocess.Popen(args, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
         p.wait()
         result = p.stdout.read().strip()
-        if result and result != b'unknown':
+        try:
             return int(result)
-        else:
+        except ValueError:
             return None
 
     def _orientation(self, image):


### PR DESCRIPTION
Using GraphicsMagick with an invalid pdf will get an error as result of calling `gm identify -format %[exif:orientation]` that will be passed to `int()` and will raise a `ValidationError`. See the attachment from this [thread](https://bugs.ghostscript.com/show_bug.cgi?id=696889) as an example.