### PR TITLE
get_thumbnail: Catch any backend exception

### DIFF
--- a/sorl/thumbnail/base.py
+++ b/sorl/thumbnail/base.py
@@ -102,13 +102,13 @@ class ThumbnailBackend(object):
         if settings.THUMBNAIL_FORCE_OVERWRITE or not thumbnail.exists():
             try:
                 source_image = default.engine.get_image(source)
-            except IOError as e:
+            except Exception as e:
                 logger.exception(e)
                 if settings.THUMBNAIL_DUMMY:
                     return DummyImageFile(geometry_string)
                 else:
-                    # if S3Storage says file doesn't exist remotely, don't try to
-                    # create it and exit early.
+                    # if storage backend says file doesn't exist remotely,
+                    # don't try to create it and exit early.
                     # Will return working empty image type; 404'd image
                     logger.warning(
                         'Remote file [%s] at [%s] does not exist',


### PR DESCRIPTION
Previously only IOError was caught while invoking
backend.get_image .  However that was limited to one
scenario of one storage backend.

THUMBNAIL_DUMMY should work with other types of errors.

Related to https://github.com/jazzband/sorl-thumbnail/issues/637
Related to https://github.com/jazzband/sorl-thumbnail/issues/638