### PR TITLE
Fix RemovedInDjango40Warning via `ugettext_lazy`

### DIFF
--- a/sorl/thumbnail/fields.py
+++ b/sorl/thumbnail/fields.py
@@ -1,7 +1,7 @@
 from django.db import models
 from django.db.models import Q
 from django import forms
-from django.utils.translation import ugettext_lazy as _
+from django.utils.translation import gettext_lazy as _
 
 from sorl.thumbnail import default
 


### PR DESCRIPTION
This PR fixes a warning issued by this package when calling `ugettext_lazy`, which has been aliased to `gettext_lazy` since Django 2.0. Details: https://github.com/django/django/blob/c1442e1192057a3bf14aecbaa1b713eee139eaff/django/utils/translation/__init__.py#L139-L149

This name (`ugettext_lazy`) is considered deprecated, and my understanding is that this project does not support any django version prior to the alias existing. The only django versions that would be expected to fail on the new import in this PR are strictly < 2.0, possibly even earlier.

I did not test this PR, but given that it's a 1 character change I hope you don't mind. I'm not aware of your designated PR process: if you would like me to do additional work for this change, please let me know!