### PR TITLE
Updated supported version of Django

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -20,6 +20,13 @@ env:
   - DJANGO=3.0  PACKAGE=redis
   - DJANGO=3.0  PACKAGE=wand
   - DJANGO=3.0  PACKAGE=dbm
+
+  - DJANGO=3.1  PACKAGE=pil
+  - DJANGO=3.1  PACKAGE=imagemagick
+  - DJANGO=3.1  PACKAGE=graphicsmagick
+  - DJANGO=3.1  PACKAGE=redis
+  - DJANGO=3.1  PACKAGE=wand
+  - DJANGO=3.1  PACKAGE=dbm
 jobs:
   include:
     - stage: deploy

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,13 +7,6 @@ python:
 env:
   - TOXENV=qa
 
-  - DJANGO=1.11 PACKAGE=pil
-  - DJANGO=1.11 PACKAGE=imagemagick
-  - DJANGO=1.11 PACKAGE=graphicsmagick
-  - DJANGO=1.11 PACKAGE=redis
-  - DJANGO=1.11 PACKAGE=wand
-  - DJANGO=1.11 PACKAGE=dbm
-
   - DJANGO=2.2  PACKAGE=pil
   - DJANGO=2.2  PACKAGE=imagemagick
   - DJANGO=2.2  PACKAGE=graphicsmagick

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -2,6 +2,10 @@
 Changes
 =======
 
+Next Release
+============
+* Drop support for Django 1.11
+
 
 12.6.3
 ======

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -5,7 +5,7 @@ Changes
 Next Release
 ============
 * Drop support for Django 1.11
-
+* Added support for Django 3.1
 
 12.6.3
 ======

--- a/README.rst
+++ b/README.rst
@@ -5,7 +5,7 @@ Thumbnails for Django.
 Features at a glance
 ====================
 
-- Support for Django 1.11, 2.2 and 3.0 following the `Django supported versions policy`_
+- Support for Django 2.2 and 3.0 following the `Django supported versions policy`_
 - Python 3 support
 - Storage support
 - Pluggable Engine support for `Pillow`_, `ImageMagick`_, `PIL`_, `Wand`_, `pgmagick`_, and `vipsthumbnail`_

--- a/README.rst
+++ b/README.rst
@@ -5,7 +5,7 @@ Thumbnails for Django.
 Features at a glance
 ====================
 
-- Support for Django 2.2 and 3.0 following the `Django supported versions policy`_
+- Support for Django 2.2, 3.0 and 3.1 following the `Django supported versions policy`_
 - Python 3 support
 - Storage support
 - Pluggable Engine support for `Pillow`_, `ImageMagick`_, `PIL`_, `Wand`_, `pgmagick`_, and `vipsthumbnail`_

--- a/docs/requirements.rst
+++ b/docs/requirements.rst
@@ -4,7 +4,7 @@ Requirements
  
 Base requirements
 =================
-- `Python`_ 2.7+
+- `Python`_ 3.6+
 - `Django`_
 - :ref:`kvstore-requirements`
 - :ref:`image-library`

--- a/tox.ini
+++ b/tox.ini
@@ -8,6 +8,7 @@ python =
 DJANGO =
   2.2: django22
   3.0: django30
+  3.1: django31
 PACKAGE =
   pil: pil
   imagemagick: imagemagick
@@ -20,7 +21,7 @@ PACKAGE =
 skipsdist = True
 envlist =
   qa
-  py{36,37,38}-django{22,30}-{pil,imagemagick,graphicsmagick,redis,dynamodb,wand,pgmagick,dbm,vipsthumbnail}
+  py{36,37,38}-django{22,30,31}-{pil,imagemagick,graphicsmagick,redis,dynamodb,wand,pgmagick,dbm,vipsthumbnail}
 
 [testenv]
 deps =
@@ -34,6 +35,7 @@ deps =
   wand: wand
   django22: django>=2.2,<2.3
   django30: django>=3.0,<3.1
+  django31: django>=3.1,<3.2
 setenv =
   PYTHONPATH = {toxinidir}:{toxinidir}
   pil: DJANGO_SETTINGS_MODULE=tests.settings.pil

--- a/tox.ini
+++ b/tox.ini
@@ -6,7 +6,6 @@ python =
 
 [travis:env]
 DJANGO =
-  1.11: django111
   2.2: django22
   3.0: django30
 PACKAGE =
@@ -21,7 +20,7 @@ PACKAGE =
 skipsdist = True
 envlist =
   qa
-  py{36,37,38}-django{111,22,30}-{pil,imagemagick,graphicsmagick,redis,dynamodb,wand,pgmagick,dbm,vipsthumbnail}
+  py{36,37,38}-django{22,30}-{pil,imagemagick,graphicsmagick,redis,dynamodb,wand,pgmagick,dbm,vipsthumbnail}
 
 [testenv]
 deps =
@@ -33,7 +32,6 @@ deps =
   dynamodb: boto
   pgmagick: pgmagick
   wand: wand
-  django111: django>=1.11,<1.12
   django22: django>=2.2,<2.3
   django30: django>=3.0,<3.1
 setenv =


### PR DESCRIPTION
Inline with Django supported versions policy, Django 3.1 should be added and 1.11 can be dropped. 

