### PR TITLE
fix: regex, tempfile suffix in convert engine

### DIFF
--- a/sorl/thumbnail/engines/convert_engine.py
+++ b/sorl/thumbnail/engines/convert_engine.py
@@ -13,7 +13,7 @@ from sorl.thumbnail.engines.base import EngineBase
 
 logger = logging.getLogger(__name__)
 
-size_re = re.compile(r'^(?:.+) (?:[A-Z]+) (?P<x>\d+)x(?P<y>\d+)')
+size_re = re.compile(r'^(?:.+) (?:[A-Z0-9]+) (?P<x>\d+)x(?P<y>\d+)')
 
 
 class Engine(EngineBase):
@@ -73,7 +73,9 @@ class Engine(EngineBase):
         """
         Returns the backend image objects from a ImageFile instance
         """
-        with NamedTemporaryFile(mode='wb', delete=False) as fp:
+        _, suffix = os.path.splitext(source.name)
+
+        with NamedTemporaryFile(mode='wb', delete=False, suffix=suffix) as fp:
             fp.write(source.read())
         return {'source': fp.name, 'options': OrderedDict(), 'size': None}
 


### PR DESCRIPTION
Addresses #532 in some scenarios.

1. If `identify` prints a file type containing numbers, eg. `BMP3`
2. In cases where ImageMagick apparently needs the correct file extension in order to use the correct delegates. Eg. for `.doc`, `.docx` it wounldn't use the `soffice` or `libreoffice` delegate and thus fail to convert.