### PR TITLE
changed getting storage for image

### DIFF
--- a/sorl/thumbnail/base.py
+++ b/sorl/thumbnail/base.py
@@ -91,7 +91,7 @@ class ThumbnailBackend:
                 options.setdefault(key, value)
 
         name = self._get_thumbnail_filename(source, geometry_string, options)
-        thumbnail = ImageFile(name, default.storage)
+        thumbnail = ImageFile(name, file_.storage)
         cached = default.kvstore.get(thumbnail)
 
         if cached:


### PR DESCRIPTION
now if there are different storages in the project,then the source storage is not taken into account when creating an thumbnail. now the source storage will be taken for the thumbnail