### PR TITLE
fix: Pillow Image.ANTIALIAS deprecation warning

### DIFF
--- a/sorl/thumbnail/engines/pil_engine.py
+++ b/sorl/thumbnail/engines/pil_engine.py
@@ -10,6 +10,7 @@ except ImportError:
     import ImageDraw
     import ImageMode
 
+ANTIALIAS = Image.Resampling.LANCZOS if hasattr(Image, 'Resampling') else Image.ANTIALIAS
 EXIF_ORIENTATION = 0x0112
 
 
@@ -230,7 +231,7 @@ class Engine(EngineBase):
     _get_image_entropy = staticmethod(histogram_entropy)
 
     def _scale(self, image, width, height):
-        return image.resize((width, height), resample=Image.ANTIALIAS)
+        return image.resize((width, height), resample=ANTIALIAS)
 
     def _crop(self, image, width, height, x_offset, y_offset):
         return image.crop((x_offset, y_offset,


### PR DESCRIPTION
In 9.1 release of Pillow, they adopted enums and deprecated constants (see https://pillow.readthedocs.io/en/stable/releasenotes/9.1.0.html#deprecations), then showing deprecation warning. This PR will try to use if Resampling exists, otherwise use old constants. It'll make future proof with Pillow.


```python
 .../sorl/thumbnail/engines/pil_engine.py:233: DeprecationWarning: ANTIALIAS is deprecated and will be removed in Pillow 10 (2023-07-01). Use Resampling.LANCZOS instead.
    return image.resize((width, height), resample=Image.ANTIALIAS)
```