### PR TITLE
docs: Fix a few typos

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -33,7 +33,7 @@ and follow the `guidelines <https://jazzband.co/about/guidelines>`_.
 
 Feel free to create a new Pull request if you want to propose a new feature.
 If you need development support or want to discuss with other developers
-join us in the channel #sorl-thumnbnail at freenode.net or Gitter.
+join us in the channel #sorl-thumbnail at freenode.net or Gitter.
 
 For releases updates and more in deep development discussion use our mailing list
 in Google Groups.

--- a/docs/contributing.rst
+++ b/docs/contributing.rst
@@ -4,7 +4,7 @@ Contributing
 
 Feel free to create a new Pull request if you want to propose a new feature
 or fix a bug.  If you need development support or want to discuss
-with other developers, join us in the channel #sorl-thumnbnail at freenode.net
+with other developers, join us in the channel #sorl-thumbnail at freenode.net
 
    irc://irc.freenode.net/#sorl-thumbnail
 

--- a/sorl/thumbnail/engines/base.py
+++ b/sorl/thumbnail/engines/base.py
@@ -98,7 +98,7 @@ class EngineBase:
             return image
         elif crop == 'smart':
             # Smart cropping is suitably different from regular cropping
-            # to warrent it's own function
+            # to warrant it's own function
             return self._entropy_crop(image, geometry[0], geometry[1], x_image, y_image)
 
         # Handle any other crop option with the backend crop function.


### PR DESCRIPTION
There are small typos in:
- README.rst
- docs/contributing.rst
- sorl/thumbnail/engines/base.py

Fixes:
- Should read `thumbnail` rather than `thumnbnail`.
- Should read `warrant` rather than `warrent`.



Semi-automated pull request generated by
https://github.com/timgates42/meticulous/blob/master/docs/NOTE.md