### PR TITLE
additional settings for storages

### DIFF
--- a/sorl/thumbnail/default.py
+++ b/sorl/thumbnail/default.py
@@ -4,6 +4,13 @@ from sorl.thumbnail.conf import settings
 from sorl.thumbnail.helpers import get_module_class
 
 
+STORAGE_INIT_PARAMS = {
+    'S3BotoStorage': {
+        'bucket_name': 'THUMBNAIL_STORAGE_AWS_BUCKET_NAME'
+    }
+}
+
+
 class Backend(LazyObject):
     def _setup(self):
         self._wrapped = get_module_class(settings.THUMBNAIL_BACKEND)()
@@ -21,7 +28,12 @@ class Engine(LazyObject):
 
 class Storage(LazyObject):
     def _setup(self):
-        self._wrapped = get_module_class(settings.THUMBNAIL_STORAGE)()
+        klass = get_module_class(settings.THUMBNAIL_STORAGE)
+        kwargs = {}
+        for param, settings_param in STORAGE_INIT_PARAMS.get(klass.__name__, {}).items():
+            if hasattr(settings, settings_param):
+                kwargs[param] = getattr(settings, settings_param)
+        self._wrapped = klass(**kwargs)
 
 
 backend = Backend()


### PR DESCRIPTION
S3BotoStorage uses the bucket name from AWS_STORAGE_BUCKET_NAME. This setting is global. If we want to use a different bucket name, sorl-thumbnail won't be able to do so. I propose to create parameters that will be tied to the storage type 