### PR TITLE
Fix usage of safe_filter

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -62,3 +62,4 @@ tests/thumbnail_kvstore.lock
 .coverage
 .tox
 htmlcov/
+coverage.xml

--- a/sorl/thumbnail/templatetags/thumbnail.py
+++ b/sorl/thumbnail/templatetags/thumbnail.py
@@ -191,8 +191,8 @@ def thumbnail(parser, token):
     return ThumbnailNode(parser, token)
 
 
-@safe_filter(error_output=False)
 @register.filter
+@safe_filter(error_output=False)
 def is_portrait(file_):
     """
     A very handy filter to determine if an image is portrait or landscape.
@@ -205,8 +205,8 @@ def is_portrait(file_):
     return image_file.is_portrait()
 
 
-@safe_filter(error_output='auto')
 @register.filter
+@safe_filter(error_output='auto')
 def margin(file_, geometry_string):
     """
     Returns the calculated margin for an image and geometry
@@ -237,8 +237,8 @@ def margin(file_, geometry_string):
     return ' '.join(['%dpx' % n for n in margin])
 
 
-@safe_filter(error_output='auto')
 @register.filter
+@safe_filter(error_output='auto')
 def background_margin(file_, geometry_string):
     """
     Returns the calculated margin for a background image and geometry
@@ -278,13 +278,13 @@ def text_filter(regex_base, value):
     return value
 
 
-@safe_filter(error_output='auto')
 @register.filter
+@safe_filter(error_output='auto')
 def markdown_thumbnails(value):
     return text_filter(r'!\[(%(re_cap)s)?\][ ]?\((%(re_img)s)\)', value)
 
 
-@safe_filter(error_output='auto')
 @register.filter
+@safe_filter(error_output='auto')
 def html_thumbnails(value):
     return text_filter(r'<img(?: alt="(%(re_cap)s)?")? src="(%(re_img)s)"', value)

--- a/tests/thumbnail_tests/templates/thumbnail4a.html
+++ b/tests/thumbnail_tests/templates/thumbnail4a.html
@@ -1,0 +1,3 @@
+{% load thumbnail %}{% spaceless %}
+{% if source|is_portrait %}yes{% else %}no{% endif %}
+{% endspaceless %}

--- a/tests/thumbnail_tests/test_templatetags.py
+++ b/tests/thumbnail_tests/test_templatetags.py
@@ -132,6 +132,24 @@ class TemplateTestCaseB(BaseTestCase):
                          '<img src="/media/test/cache/82/62/8262858c5f95f2bd7715d7aaa3e52b11.jpg" '
                          'width="79" height="66" class="landscape">')
 
+        val = render_to_string('thumbnail4.html', {
+            'source': 'https://dummyimage.com/100x120/',
+            'dims': 'x66',
+        }).strip()
+        self.assertEqual(val, '<img width="1" height="1" class="portrait">')
+
+        with override_settings(THUMBNAIL_DEBUG=True):
+            with self.assertRaises(FileNotFoundError):
+                render_to_string('thumbnail4a.html', {
+                    'source': 'broken.jpeg',
+                }).strip()
+
+        with override_settings(THUMBNAIL_DEBUG=False):
+            val = render_to_string('thumbnail4a.html', {
+                'source': 'broken.jpeg',
+            }).strip()
+            self.assertEqual(val, 'no')
+
     def test_empty(self):
         val = render_to_string('thumbnail5.html', {}).strip()
         self.assertEqual(val, '<p>empty</p>')


### PR DESCRIPTION
Hi,

`safe_filter` is currently applied in a way which results in the functions actually executed on template rendering not being decorated.

Old example

```
@safe_filter(error_output=False)
@register.filter
def is_portrait(file_):
    ...
```

New example after merging this PR:

```
@register.filter
@safe_filter(error_output=False)
def is_portrait(file_):
    ...
```

Order of old example resulted in `register.filter` being called on the actual function `is_portrait` and the result of this than being decorated by `safe_filter`. Changing order ensures that a with `safe_filter` decorated `is_portrait` is registered as template filter.

The commit 22604926433fd8a7f8ca2d3f1560cb4b09e4f056 demonstrates this by just extending the tests to show the failure. Commit after this fixes it.

Please consider applying this :-) 