### PR TITLE
Add management command to delete based on THUMBNAIL_CACHE_TIMEOUT

### DIFF
--- a/sorl/thumbnail/management/commands/thumbnail.py
+++ b/sorl/thumbnail/management/commands/thumbnail.py
@@ -4,7 +4,12 @@ from sorl.thumbnail import default
 from sorl.thumbnail.images import delete_all_thumbnails
 
 
-VALID_LABELS = ['cleanup', 'clear', 'clear_delete_referenced', 'clear_delete_all']
+VALID_LABELS = [
+    'cleanup',
+    'clear',
+    'clear_delete_referenced',
+    'clear_delete_all',
+]
 
 
 class Command(BaseCommand):


### PR DESCRIPTION
Resolves #721

This management command deletes thumbnails in the cache, kvstore (database) and storage (filesystem) if the file's created time is before `THUMBNAIL_CACHE_TIMEOUT` seconds ago.

Usage:

```sh
python manage.py thumbnail cleanup_delete_timeout
```