### PR TITLE
Create thumbnail from files saved with wrong extension

### DIFF
--- a/sorl/thumbnail/engines/pil_engine.py
+++ b/sorl/thumbnail/engines/pil_engine.py
@@ -151,6 +151,8 @@ class Engine(EngineBase):
             # Pillow JPEG doesn't allow RGBA anymore. It was converted to RGB before.
             if image.mode == 'RGBA' and format != 'JPEG':
                 return image  # RGBA is just RGB + Alpha
+            if image.mode == 'RGBA' and format == 'JPEG' and image.format != 'JPEG':
+                return image.convert('RGB')
             if image.mode == 'LA' or (
                 image.mode == 'P' and 'transparency' in image.info and format != 'JPEG'
             ):


### PR DESCRIPTION
If a png file has been saved with wrong extension (example: the png image has been saved with .jpg) the following error will be throw `OSError: cannot write mode RGBA as JPEG django thumbnail`. With Pillow you can get the image format from the file content and not just reading file extension.

In this zip archive there are the original png image and the same image but with wrong extension
[wrong_jpg.zip](https://github.com/jazzband/sorl-thumbnail/files/10943260/wrong_jpg.zip)

