### PR TITLE
replace flake8 with ruff

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,5 +1,6 @@
-- repo: https://github.com/astral-sh/ruff-pre-commit
-  rev: v0.6.1
-  hooks:
-    - id: ruff
-      args: [ --fix ]
+repos:
+  - repo: https://github.com/astral-sh/ruff-pre-commit
+    rev: v0.6.1
+    hooks:
+      - id: ruff
+        args: [ --fix ]

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,5 +1,5 @@
-repos:
-  - repo: https://github.com/PyCQA/flake8
-    rev: 6.1.0
-    hooks:
-      - id: flake8
+- repo: https://github.com/astral-sh/ruff-pre-commit
+  rev: v0.6.1
+  hooks:
+    - id: ruff
+      args: [ --fix ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,17 @@
+[tool.ruff]
+exclude = [
+    ".tox",
+    "docs/*",
+    "*/migrations/*",
+    "tests/settings/*",
+    "sorl/thumbnail/__init__.py",
+    "sorl/thumbnail/admin/__init__.py"
+]
+line-length = 100
+
+[tool.ruff.lint]
+select = ["B", "C901", "E", "F", "W"]
+ignore = ["B904", "B017"]
+
+[tool.ruff.lint.mccabe]
+max-complexity = 15

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,22 +1,6 @@
 [bdist_wheel]
 universal = 0
 
-;; flake8 analyzes and detect varios errors in the source code.
-
-[flake8]
-# D105 - Missing docstring in magic method `__func__`
-ignore = D105,W503
-max-line-length = 100
-exclude = .git,
-          .tox,
-          docs/*,
-          */migrations/*,
-          tests/settings/*,
-          sorl/thumbnail/__init__.py,
-          sorl/thumbnail/admin/__init__.py
-
-max_complexity = 15
-
 ;; Coverage.py, Code coverage testing for Python.
 
 [cov:run]

--- a/tox.ini
+++ b/tox.ini
@@ -58,9 +58,8 @@ commands =
 [testenv:py38-qa]
 skip_install = True
 deps =
-  flake8
-  flake8-bugbear
+  ruff
   rstvalidator
 commands =
-  flake8 --show-source sorl/
+  ruff check sorl/
   python -m rstvalidator README.rst CHANGES.rst CONTRIBUTING.rst


### PR DESCRIPTION
This PR replaces flake8 with ruff, a very fast linter and code formatter. Perhaps we need to use code formatter?