### PR TITLE
ruff: sort imports

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,7 +10,7 @@ exclude = [
 line-length = 100
 
 [tool.ruff.lint]
-select = ["B", "C901", "E", "F", "W"]
+select = ["B", "C901", "E", "F", "I", "W"]
 ignore = ["B904", "B017"]
 
 [tool.ruff.lint.mccabe]

--- a/setup.py
+++ b/setup.py
@@ -1,4 +1,4 @@
-from setuptools import setup, find_packages
+from setuptools import find_packages, setup
 
 setup(
     name='sorl-thumbnail',

--- a/sorl/__init__.py
+++ b/sorl/__init__.py
@@ -1,4 +1,4 @@
-from importlib.metadata import version, PackageNotFoundError
+from importlib.metadata import PackageNotFoundError, version
 
 try:
     __version__ = version("sorl-thumbnail")

--- a/sorl/thumbnail/admin/current.py
+++ b/sorl/thumbnail/admin/current.py
@@ -2,9 +2,9 @@ import logging
 
 from django import forms
 from django.utils.safestring import mark_safe
+
 from sorl.thumbnail.fields import ImageField
 from sorl.thumbnail.shortcuts import get_thumbnail
-
 
 logger = logging.getLogger(__name__)
 

--- a/sorl/thumbnail/base.py
+++ b/sorl/thumbnail/base.py
@@ -2,12 +2,12 @@ import logging
 import os
 import re
 
-from sorl.thumbnail.conf import settings, defaults as default_settings
-from sorl.thumbnail.helpers import tokey, serialize
-from sorl.thumbnail.images import ImageFile, DummyImageFile
 from sorl.thumbnail import default
+from sorl.thumbnail.conf import defaults as default_settings
+from sorl.thumbnail.conf import settings
+from sorl.thumbnail.helpers import serialize, tokey
+from sorl.thumbnail.images import DummyImageFile, ImageFile
 from sorl.thumbnail.parsers import parse_geometry
-
 
 logger = logging.getLogger(__name__)
 

--- a/sorl/thumbnail/conf/__init__.py
+++ b/sorl/thumbnail/conf/__init__.py
@@ -1,4 +1,5 @@
 from django.conf import settings as user_settings
+
 from sorl.thumbnail.conf import defaults
 
 

--- a/sorl/thumbnail/engines/base.py
+++ b/sorl/thumbnail/engines/base.py
@@ -1,7 +1,6 @@
 from sorl.thumbnail.conf import settings
 from sorl.thumbnail.helpers import toint
-from sorl.thumbnail.parsers import parse_crop
-from sorl.thumbnail.parsers import parse_cropbox
+from sorl.thumbnail.parsers import parse_crop, parse_cropbox
 
 
 class EngineBase:

--- a/sorl/thumbnail/engines/convert_engine.py
+++ b/sorl/thumbnail/engines/convert_engine.py
@@ -1,11 +1,11 @@
-import re
-import os
-import subprocess
 import logging
+import os
+import re
+import subprocess
 from collections import OrderedDict
 
-from django.utils.encoding import smart_str
 from django.core.files.temp import NamedTemporaryFile
+from django.utils.encoding import smart_str
 
 from sorl.thumbnail.base import EXTENSIONS
 from sorl.thumbnail.conf import settings

--- a/sorl/thumbnail/engines/pgmagick_engine.py
+++ b/sorl/thumbnail/engines/pgmagick_engine.py
@@ -1,5 +1,5 @@
-from pgmagick import Blob, Geometry, Image, ImageType
-from pgmagick import InterlaceType, OrientationType
+from pgmagick import Blob, Geometry, Image, ImageType, InterlaceType, OrientationType
+
 from sorl.thumbnail.engines.base import EngineBase
 
 try:

--- a/sorl/thumbnail/engines/pil_engine.py
+++ b/sorl/thumbnail/engines/pil_engine.py
@@ -3,11 +3,11 @@ from io import BytesIO
 from sorl.thumbnail.engines.base import EngineBase
 
 try:
-    from PIL import Image, ImageFile, ImageDraw, ImageFilter, ImageMode
+    from PIL import Image, ImageDraw, ImageFile, ImageFilter, ImageMode
 except ImportError:
     import Image
-    import ImageFile
     import ImageDraw
+    import ImageFile
     import ImageMode
 
 if hasattr(Image, 'Resampling'):
@@ -36,7 +36,7 @@ def color_count(image):
 
 def histogram_entropy_py(image):
     """ Calculate the entropy of an images' histogram. """
-    from math import log2, fsum
+    from math import fsum, log2
     histosum = float(color_count(image))
     histonorm = (histocol / histosum for histocol in image.histogram())
     return -fsum(p * log2(p) for p in histonorm if p != 0.0)

--- a/sorl/thumbnail/engines/vipsthumbnail_engine.py
+++ b/sorl/thumbnail/engines/vipsthumbnail_engine.py
@@ -1,15 +1,14 @@
-import re
 import os
+import re
 import subprocess
 from collections import OrderedDict
 
-from django.utils.encoding import smart_str
 from django.core.files.temp import NamedTemporaryFile
+from django.utils.encoding import smart_str
 
 from sorl.thumbnail.base import EXTENSIONS
 from sorl.thumbnail.conf import settings
 from sorl.thumbnail.engines.base import EngineBase
-
 
 size_re = re.compile(r'^(?:.+) (?P<x>\d+)x(?P<y>\d+)')
 

--- a/sorl/thumbnail/engines/wand_engine.py
+++ b/sorl/thumbnail/engines/wand_engine.py
@@ -2,9 +2,10 @@
 Wand (>=v0.3.0) engine for Sorl-thumbnail
 '''
 
+from wand import exceptions
 from wand.image import Image
 from wand.version import MAGICK_VERSION_NUMBER
-from wand import exceptions
+
 from sorl.thumbnail.engines.base import EngineBase
 
 

--- a/sorl/thumbnail/fields.py
+++ b/sorl/thumbnail/fields.py
@@ -1,10 +1,9 @@
+from django import forms
 from django.db import models
 from django.db.models import Q
-from django import forms
 from django.utils.translation import gettext_lazy as _
 
 from sorl.thumbnail import default
-
 
 __all__ = ('ImageField', 'ImageFormField')
 

--- a/sorl/thumbnail/images.py
+++ b/sorl/thumbnail/images.py
@@ -5,16 +5,17 @@ import re
 from functools import lru_cache
 from urllib.error import URLError
 from urllib.parse import quote, quote_plus, urlsplit, urlunsplit
-from urllib.request import urlopen, Request
+from urllib.request import Request, urlopen
 
-from django.core.files.base import File, ContentFile
+from django.core.files.base import ContentFile, File
 from django.core.files.storage import Storage  # , default_storage
 from django.utils.encoding import force_str
 from django.utils.functional import LazyObject, empty
+
 from sorl.thumbnail import default
 from sorl.thumbnail.conf import settings
 from sorl.thumbnail.default import storage as default_storage
-from sorl.thumbnail.helpers import ThumbnailError, tokey, get_module_class, deserialize
+from sorl.thumbnail.helpers import ThumbnailError, deserialize, get_module_class, tokey
 from sorl.thumbnail.parsers import parse_geometry
 
 url_pat = re.compile(r'^(https?|ftp):\/\/')

--- a/sorl/thumbnail/kvstores/base.py
+++ b/sorl/thumbnail/kvstores/base.py
@@ -1,6 +1,6 @@
 from sorl.thumbnail.conf import settings
-from sorl.thumbnail.helpers import serialize, deserialize, ThumbnailError
-from sorl.thumbnail.images import serialize_image_file, deserialize_image_file
+from sorl.thumbnail.helpers import ThumbnailError, deserialize, serialize
+from sorl.thumbnail.images import deserialize_image_file, serialize_image_file
 
 
 def add_prefix(key, identity='image'):

--- a/sorl/thumbnail/kvstores/cached_db_kvstore.py
+++ b/sorl/thumbnail/kvstores/cached_db_kvstore.py
@@ -1,6 +1,7 @@
-from django.core.cache import cache, caches, InvalidCacheBackendError
-from sorl.thumbnail.kvstores.base import KVStoreBase
+from django.core.cache import InvalidCacheBackendError, cache, caches
+
 from sorl.thumbnail.conf import settings
+from sorl.thumbnail.kvstores.base import KVStoreBase
 from sorl.thumbnail.models import KVStore as KVStoreModel
 
 

--- a/sorl/thumbnail/kvstores/dbm_kvstore.py
+++ b/sorl/thumbnail/kvstores/dbm_kvstore.py
@@ -1,8 +1,7 @@
 import os
 
-from sorl.thumbnail.kvstores.base import KVStoreBase
 from sorl.thumbnail.conf import settings
-
+from sorl.thumbnail.kvstores.base import KVStoreBase
 
 try:
     import anydbm as dbm

--- a/sorl/thumbnail/kvstores/dynamodb_kvstore.py
+++ b/sorl/thumbnail/kvstores/dynamodb_kvstore.py
@@ -1,7 +1,8 @@
-from boto.dynamodb2.table import Table
 import boto
-from sorl.thumbnail.kvstores.base import KVStoreBase
+from boto.dynamodb2.table import Table
+
 from sorl.thumbnail.conf import settings
+from sorl.thumbnail.kvstores.base import KVStoreBase
 
 
 class KVStore(KVStoreBase):

--- a/sorl/thumbnail/kvstores/redis_kvstore.py
+++ b/sorl/thumbnail/kvstores/redis_kvstore.py
@@ -1,6 +1,7 @@
 import redis
-from sorl.thumbnail.kvstores.base import KVStoreBase
+
 from sorl.thumbnail.conf import settings
+from sorl.thumbnail.kvstores.base import KVStoreBase
 
 
 class KVStore(KVStoreBase):

--- a/sorl/thumbnail/management/commands/thumbnail.py
+++ b/sorl/thumbnail/management/commands/thumbnail.py
@@ -3,7 +3,6 @@ from django.core.management.base import BaseCommand
 from sorl.thumbnail import default
 from sorl.thumbnail.images import delete_all_thumbnails
 
-
 VALID_LABELS = ['cleanup', 'clear', 'clear_delete_referenced', 'clear_delete_all']
 
 

--- a/sorl/thumbnail/parsers.py
+++ b/sorl/thumbnail/parsers.py
@@ -2,7 +2,6 @@ import re
 
 from sorl.thumbnail.helpers import ThumbnailError, toint
 
-
 bgpos_pat = re.compile(r'^(?P<value>\d+)(?P<unit>%|px)$')
 geometry_pat = re.compile(r'^(?P<x>\d+)?(?:x(?P<y>\d+))?$')
 

--- a/sorl/thumbnail/templatetags/thumbnail.py
+++ b/sorl/thumbnail/templatetags/thumbnail.py
@@ -1,20 +1,19 @@
 import decimal
 import logging
-import sys
-import re
 import os
+import re
+import sys
 from functools import wraps
 
+from django.conf import settings
 from django.template import Library, Node, NodeList, TemplateSyntaxError
 from django.utils.encoding import smart_str
-from django.conf import settings
 
-from sorl.thumbnail.conf import settings as sorl_settings
 from sorl.thumbnail import default
-from sorl.thumbnail.images import ImageFile, DummyImageFile
+from sorl.thumbnail.conf import settings as sorl_settings
+from sorl.thumbnail.images import DummyImageFile, ImageFile
 from sorl.thumbnail.parsers import parse_geometry
 from sorl.thumbnail.shortcuts import get_thumbnail
-
 
 register = Library()
 kw_pat = re.compile(r'^(?P<key>[\w]+)=(?P<value>.+)$')

--- a/tests/thumbnail_tests/test_alternative_resolutions.py
+++ b/tests/thumbnail_tests/test_alternative_resolutions.py
@@ -4,11 +4,10 @@ import pytest
 
 from sorl.thumbnail import get_thumbnail
 from sorl.thumbnail.conf import settings
-from sorl.thumbnail.images import ImageFile
 from sorl.thumbnail.engines.pil_engine import Engine as PILEngine
+from sorl.thumbnail.images import ImageFile
 
 from .utils import BaseStorageTestCase
-
 
 pytestmark = pytest.mark.django_db
 

--- a/tests/thumbnail_tests/test_backends.py
+++ b/tests/thumbnail_tests/test_backends.py
@@ -1,23 +1,23 @@
-from io import StringIO
 import os
 import platform
-import sys
 import shutil
+import sys
 import unittest
-from PIL import Image
+from io import StringIO
 
 import pytest
 from django.test import TestCase
 from django.test.utils import override_settings
+from PIL import Image
 
 from sorl.thumbnail import default, delete, get_thumbnail
 from sorl.thumbnail.base import ThumbnailBackend
 from sorl.thumbnail.conf import settings
 from sorl.thumbnail.helpers import get_module_class
 from sorl.thumbnail.images import ImageFile
-from .utils import BaseTestCase, FakeFile, same_open_fd_count
-from .models import Item
 
+from .models import Item
+from .utils import BaseTestCase, FakeFile, same_open_fd_count
 
 pytestmark = pytest.mark.django_db
 

--- a/tests/thumbnail_tests/test_commands.py
+++ b/tests/thumbnail_tests/test_commands.py
@@ -1,13 +1,13 @@
-from io import StringIO
 import os
+from io import StringIO
 
 import pytest
 from django.core import management
 
 from sorl.thumbnail.conf import settings
+
 from .models import Item
 from .utils import BaseTestCase
-
 
 pytestmark = pytest.mark.django_db
 

--- a/tests/thumbnail_tests/test_engines.py
+++ b/tests/thumbnail_tests/test_engines.py
@@ -1,24 +1,24 @@
 import os
 import platform
 import unittest
-from subprocess import Popen, PIPE
+from subprocess import PIPE, Popen
 
 import pytest
-from PIL import Image
 from django.core.files.storage import default_storage
 from django.template.loader import render_to_string
+from PIL import Image
 
 from sorl.thumbnail import default
 from sorl.thumbnail.base import ThumbnailBackend
 from sorl.thumbnail.conf import settings
+from sorl.thumbnail.engines.pil_engine import Engine as PILEngine
 from sorl.thumbnail.helpers import get_module_class
 from sorl.thumbnail.images import ImageFile
 from sorl.thumbnail.parsers import parse_geometry
 from sorl.thumbnail.templatetags.thumbnail import margin
-from sorl.thumbnail.engines.pil_engine import Engine as PILEngine
+
 from .models import Item
 from .utils import BaseTestCase
-
 
 pytestmark = pytest.mark.django_db
 

--- a/tests/thumbnail_tests/test_filters.py
+++ b/tests/thumbnail_tests/test_filters.py
@@ -3,7 +3,6 @@ from django.template.loader import render_to_string
 
 from tests.thumbnail_tests.utils import BaseTestCase
 
-
 pytestmark = pytest.mark.django_db
 
 

--- a/tests/thumbnail_tests/test_storage.py
+++ b/tests/thumbnail_tests/test_storage.py
@@ -1,11 +1,11 @@
 import unittest
+
 import pytest
 
-from sorl.thumbnail import get_thumbnail, default
+from sorl.thumbnail import default, get_thumbnail
 from sorl.thumbnail.helpers import get_module_class
 
 from .utils import BaseStorageTestCase
-
 
 pytestmark = pytest.mark.django_db
 

--- a/tests/thumbnail_tests/test_templatetags.py
+++ b/tests/thumbnail_tests/test_templatetags.py
@@ -1,18 +1,18 @@
 import os
 import re
-from subprocess import Popen, PIPE
-from PIL import Image
+from subprocess import PIPE, Popen
 
+import pytest
 from django.template.loader import render_to_string
 from django.test import Client, TestCase
 from django.test.utils import override_settings
-import pytest
+from PIL import Image
 
 from sorl.thumbnail.conf import settings
 from sorl.thumbnail.engines.pil_engine import Engine as PILEngine
-from .models import Item
-from .utils import BaseTestCase, DATA_DIR
 
+from .models import Item
+from .utils import DATA_DIR, BaseTestCase
 
 pytestmark = pytest.mark.django_db
 

--- a/tests/thumbnail_tests/urls.py
+++ b/tests/thumbnail_tests/urls.py
@@ -7,7 +7,6 @@ from django.views.static import serve
 
 from .views import direct_to_template
 
-
 urlpatterns = [
     url(r'^media/(?P<path>.+)$', serve,
         {'document_root': settings.MEDIA_ROOT, 'show_indexes': True}),

--- a/tests/thumbnail_tests/utils.py
+++ b/tests/thumbnail_tests/utils.py
@@ -1,7 +1,7 @@
+import logging
 import os
 import shutil
 import unittest
-import logging
 from contextlib import contextmanager
 from subprocess import check_output
 
@@ -11,6 +11,7 @@ from sorl.thumbnail.conf import settings
 from sorl.thumbnail.helpers import get_module_class
 from sorl.thumbnail.images import ImageFile
 from sorl.thumbnail.log import ThumbnailLogHandler
+
 from .models import Item
 from .storage import MockLoggingHandler
 

--- a/tests/thumbnail_tests/views.py
+++ b/tests/thumbnail_tests/views.py
@@ -1,5 +1,5 @@
-from django.template import loader
 from django.http import HttpResponse
+from django.template import loader
 
 
 def direct_to_template(request, template, mimetype=None, **kwargs):


### PR DESCRIPTION
This PR configures Ruff to check if imports are sorted, also fixes sort errors in the code. I find sorted imports are very useful for large code maintenance for long time, even thought it is trivial thing.