### PR TITLE
consolidate dev tools configs into pyproject.toml

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,3 +1,24 @@
+[tool.coverage.run]
+source = ["sorl"]
+omit = [
+    "*/sorl-thumbnail/sorl/__init__.py",
+    "*/sorl/thumbnail/__init__.py",
+    "*/sorl/thumbnail/conf/__init__.py",
+    "*/sorl/thumbnail/admin/__init__.py",
+]
+
+[tool.coverage.report]
+exclude_lines = [
+    "pragma: no cover",
+    "if __name__ == .__main__.:",
+]
+
+[tool.pytest.ini_options]
+python_files = ["test_*.py", "*tests.py"]
+norecursedirs =[".*", "tmp*", "__pycache__"]
+testpaths = ["tests"]
+django_find_project = false
+
 [tool.ruff]
 exclude = [
     ".tox",

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,24 +1,2 @@
 [bdist_wheel]
 universal = 0
-
-;; Coverage.py, Code coverage testing for Python.
-
-[cov:run]
-source = sorl
-omit = */sorl-thumbnail/sorl/__init__.py
-       */sorl/thumbnail/__init__.py
-       */sorl/thumbnail/conf/__init__.py
-       */sorl/thumbnail/admin/__init__.py
-
-[cov:report]
-exclude_lines = pragma: no cover
-                if __name__ == .__main__.:
-
-;; The pytest framework
-
-[tool:pytest]
-python_files = test_*.py *tests.py
-norecursedirs = .* tmp* __pycache__
-testpaths = tests
-django_find_project = false
-


### PR DESCRIPTION
This PR consolidates dev tools configs into pyproject.toml, a modern configuration for Python projects. Currently, they're split in setup.cfg and pyproject.toml.

Tests and their coverage must be same as before.