### PR TITLE
Fixes #773: Accept a tuple as blur radius and ensure to call PIL blur filter with a tuple

### DIFF
--- a/sorl/thumbnail/engines/base.py
+++ b/sorl/thumbnail/engines/base.py
@@ -118,8 +118,11 @@ class EngineBase:
         """
         Wrapper for ``_blur``
         """
-        if options.get('blur'):
-            return self._blur(image, int(options.get('blur')))
+        radius = options.get('blur')
+        if radius:
+            if isinstance(radius, str):
+                radius = int(radius)
+            return self._blur(image, radius)
         return image
 
     def padding(self, image, geometry, options):

--- a/sorl/thumbnail/engines/pil_engine.py
+++ b/sorl/thumbnail/engines/pil_engine.py
@@ -3,7 +3,8 @@ from io import BytesIO
 from sorl.thumbnail.engines.base import EngineBase
 
 try:
-    from PIL import Image, ImageDraw, ImageFile, GaussianBlur, ImageMode
+    from PIL import Image, ImageDraw, ImageFile, ImageMode
+    from PIL.ImageFilter import GaussianBlur
 except ImportError:
     import Image
     import ImageDraw

--- a/sorl/thumbnail/engines/pil_engine.py
+++ b/sorl/thumbnail/engines/pil_engine.py
@@ -75,7 +75,10 @@ class GaussianBlur(ImageFilter.Filter):
         self.radius = radius
 
     def filter(self, image):
-        return image.gaussian_blur(self.radius)
+        xy = self.radius
+        if isinstance(xy, (int, float)):
+            xy = (xy, xy)
+        return image.gaussian_blur(xy)
 
 
 class Engine(EngineBase):

--- a/sorl/thumbnail/engines/pil_engine.py
+++ b/sorl/thumbnail/engines/pil_engine.py
@@ -3,7 +3,7 @@ from io import BytesIO
 from sorl.thumbnail.engines.base import EngineBase
 
 try:
-    from PIL import Image, ImageDraw, ImageFile, ImageFilter, ImageMode
+    from PIL import Image, ImageDraw, ImageFile, GaussianBlur, ImageMode
 except ImportError:
     import Image
     import ImageDraw
@@ -66,19 +66,6 @@ def round_rectangle(size, radius, fill):
     rectangle.paste(corner.rotate(180), (width - radius, height - radius))
     rectangle.paste(corner.rotate(270), (width - radius, 0))
     return rectangle
-
-
-class GaussianBlur(ImageFilter.Filter):
-    name = "GaussianBlur"
-
-    def __init__(self, radius=2):
-        self.radius = radius
-
-    def filter(self, image):
-        xy = self.radius
-        if isinstance(xy, (int, float)):
-            xy = (xy, xy)
-        return image.gaussian_blur(xy)
 
 
 class Engine(EngineBase):

--- a/tests/thumbnail_tests/test_engines.py
+++ b/tests/thumbnail_tests/test_engines.py
@@ -59,6 +59,15 @@ class SimpleTestCase(BaseTestCase):
         self.assertEqual(t.x, 400)
         self.assertEqual(t.y, 300)
 
+    @unittest.skipIf('pil_engine' not in settings.THUMBNAIL_ENGINE, 'blur is only supported in PIL')
+    def test_crop_and_blur(self):
+        item = Item.objects.get(image='200x100.jpg')
+
+        t = self.BACKEND.get_thumbnail(item.image, '100x100', crop="center", blur='3')
+
+        self.assertEqual(t.x, 100)
+        self.assertEqual(t.y, 100)
+
     def test_kvstore(self):
         im = ImageFile(Item.objects.get(image='500x500.jpg').image)
         self.KVSTORE.delete_thumbnails(im)


### PR DESCRIPTION
This pr fixes #773. Pillow has changed the accepted type of the blur radius from int to tuple(int, int).