### PR TITLE
fix performance in convert engine: exif orientation

### DIFF
--- a/sorl/thumbnail/engines/convert_engine.py
+++ b/sorl/thumbnail/engines/convert_engine.py
@@ -110,7 +110,8 @@ class Engine(EngineBase):
 
     def _get_exif_orientation(self, image):
         args = settings.THUMBNAIL_IDENTIFY.split()
-        args.extend(['-format', '%[exif:orientation]', image['source']])
+        image_param = f"{image['source']}[0]"
+        args.extend(["-format", "%[exif:orientation]", image_param])
         p = subprocess.Popen(args, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
         p.wait()
         result = p.stdout.read().strip()


### PR DESCRIPTION
In other calls to the ImageMagick commandline tools in the same class, the suffix "[0]" is added so it only looks at the first page if it's a multi-page document such as a PDF.

For some reason, this is missing in the `_get_exif_orientation()` method, and may cause very long runtimes when dealing with large documents (several hundred pages of PDF).

I had a roughly 300 page PDF (plain text only, about 2.5MB) to reproduce, and the runtime of the `get_thumbnail()` call went down from around 90s to roughly 600ms.