### PR TITLE
Reduce tested Python versions on GitHub

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -7,7 +7,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ['3.9', '3.10', '3.11', '3.12', '3.13']
+        python-version: ['3.9', '3.13']
         target: [pil, imagemagick, graphicsmagick, redis, wand, dbm]
 
         include:


### PR DESCRIPTION
As docker hub has now limited downloads, it'd be best to limit the number of test combinations. Testing minimal and maximal Python version should be enough. Moreover, this also limits the energy load for each test run.