### PR TITLE
Add support for Django 5.2

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -8,6 +8,7 @@ Unreleased
   The old way of specifying a dotted path to a Storage module is still supported.
 * Confirmed support for Python 3.13 (on Django 5.1+).
 * Drop support for Python 3.8.
+* Add support for Django 5.2
 
 12.11.0
 =======

--- a/README.rst
+++ b/README.rst
@@ -5,7 +5,7 @@ Thumbnails for Django.
 Features at a glance
 ====================
 
-- Support for Django 4.2, 5.0 and 5.1 following the `Django supported versions policy`_
+- Support for Django 4.2, 5.0, 5.1, and 5.2 following the `Django supported versions policy`_
 - Storage support
 - Pluggable Engine support for `Pillow`_, `ImageMagick`_, `PIL`_, `Wand`_, `pgmagick`_, and `vipsthumbnail`_
 - Pluggable Key Value Store support (cached db, redis, and dynamodb by AWS)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,6 +34,7 @@ classifiers=[
     'Framework :: Django :: 4.2',
     'Framework :: Django :: 5.0',
     'Framework :: Django :: 5.1',
+    'Framework :: Django :: 5.2',
 ]
 
 [project.urls]

--- a/tox.ini
+++ b/tox.ini
@@ -11,6 +11,7 @@ DJANGO =
   4.2: django42
   5.0: django50
   5.1: django51
+  5.2: django52
 TARGET =
   pil: pil
   imagemagick: imagemagick
@@ -27,6 +28,7 @@ envlist =
   py{39,310,311,312}-django{42}-{pil,imagemagick,graphicsmagick,redis,dynamodb,wand,pgmagick,dbm,vipsthumbnail}
   py{310,311,312}-django{50}-{pil,imagemagick,graphicsmagick,redis,dynamodb,wand,pgmagick,dbm,vipsthumbnail}
   py{310,311,312,313}-django{51}-{pil,imagemagick,graphicsmagick,redis,dynamodb,wand,pgmagick,dbm,vipsthumbnail}
+  py{310,311,312,313}-django{52}-{pil,imagemagick,graphicsmagick,redis,dynamodb,wand,pgmagick,dbm,vipsthumbnail}
 
 [testenv]
 deps =
@@ -39,6 +41,7 @@ deps =
   django42: django>=4.2,<4.3
   django50: django>=5.0,<5.1
   django51: django>=5.1,<5.2
+  django52: django>=5.2,<5.3
 
 setenv =
   PYTHONPATH = {toxinidir}:{toxinidir}


### PR DESCRIPTION
This confirms support for Django 5.2 by modifying the test matrices, classifiers, and documentation alongside currently supported versions 4.2, 5.0, and 5.1.

I did not remove Django 5.0 support yet, even though it stopped being supported on April 2, 2025. I would be happy to add a commit to do so.