### PR TITLE
Make AdminImageWidget inherit from AdminFileWidget

### DIFF
--- a/sorl/thumbnail/admin/current.py
+++ b/sorl/thumbnail/admin/current.py
@@ -1,6 +1,6 @@
 import logging
 
-from django import forms
+from django.contrib.admin.widgets import AdminFileWidget
 from django.utils.safestring import mark_safe
 
 from sorl.thumbnail.fields import ImageField
@@ -9,17 +9,11 @@ from sorl.thumbnail.shortcuts import get_thumbnail
 logger = logging.getLogger(__name__)
 
 
-class AdminImageWidget(forms.ClearableFileInput):
+class AdminImageWidget(AdminFileWidget):
     """
     An ImageField Widget for django.contrib.admin that shows a thumbnailed
     image as well as a link to the current one if it hase one.
     """
-
-    template_with_initial = (
-        '%(clear_template)s <br>'
-        '<label>%(input_text)s: %(input)s</label>'
-    )
-    template_with_clear = '<label>%(clear_checkbox_label)s: %(clear)s</label>'
 
     def render(self, name, value, attrs=None, **kwargs):
         output = super().render(name, value, attrs, **kwargs)

--- a/tests/settings/default.py
+++ b/tests/settings/default.py
@@ -33,6 +33,7 @@ MEDIA_ROOT = pjoin(PROJ_ROOT, 'media')
 MEDIA_URL = '/media/'
 ROOT_URLCONF = 'tests.thumbnail_tests.urls'
 INSTALLED_APPS = (
+    'django.contrib.admin',
     'django.contrib.auth',
     'django.contrib.contenttypes',
     'sorl.thumbnail',
@@ -51,4 +52,12 @@ MIDDLEWARE = (
     'django.contrib.messages.middleware.MessageMiddleware',
     'django.middleware.clickjacking.XFrameOptionsMiddleware',
 )
+SILENCED_SYSTEM_CHECKS = [
+    # The admin is in INSTALLED_APPS for template discovery only, so silence
+    # checks about auth and messages not installed.
+    "admin.E402",
+    "admin.E404",
+    "admin.E406",
+    "admin.W411",
+]
 THUMBNAIL_REDIS_SSL = False


### PR DESCRIPTION
Fix: the AdminImageWidget inherited from a plain forms widget, not an admin widget with appropriate customizations for wrapping the clear checkbox in a `<span>` and rendering a `<fieldset>`.

**Before**
Notice checkbox not in line with label.
<img width="907" height="192" alt="before" src="https://github.com/user-attachments/assets/c63518eb-070a-4dbb-b906-36bc6d944688" />


**After**
Checkbox aligned with label, also markup uses `<fieldset>`.
<img width="899" height="161" alt="after" src="https://github.com/user-attachments/assets/2edd130b-820c-4f02-bcf8-0d338592461f" />




Tested on Django 6.0.6
