### PR TITLE
Fix: sorl/thumbnail/engines/base.py's _calculate_scaling_factor() did...

### DIFF
--- a/sorl/thumbnail/engines/base.py
+++ b/sorl/thumbnail/engines/base.py
@@ -67,7 +67,7 @@ class EngineBase:
     def _calculate_scaling_factor(self, x_image, y_image, geometry, options):
         crop = options['crop']
         factors = (geometry[0] / x_image, geometry[1] / y_image)
-        return max(factors) if crop else min(factors)
+        return min(factors) if not crop or crop == 'noop' else max(factors)
 
     def scale(self, image, geometry, options):
         """

--- a/tests/thumbnail_tests/test_engines.py
+++ b/tests/thumbnail_tests/test_engines.py
@@ -251,6 +251,20 @@ class SimpleTestCase(BaseTestCase):
         self.assertEqual(t.x, 100)
         self.assertEqual(t.y, 100)
 
+    def test_calculate_scaling_factor_noop_crop(self):
+        engine = PILEngine()
+
+        factor_none = engine._calculate_scaling_factor(800, 600, (400, 400), {'crop': None})
+        factor_noop = engine._calculate_scaling_factor(800, 600, (400, 400), {'crop': 'noop'})
+        factor_center = engine._calculate_scaling_factor(800, 600, (400, 400), {'crop': 'center'})
+
+        # crop='noop' must scale identically to crop being unset (fit-within-bounds).
+        self.assertEqual(factor_noop, factor_none)
+        # A real crop value should still use the max()-based, crop-fitting behavior.
+        self.assertNotEqual(factor_noop, factor_center)
+        self.assertEqual(factor_center, max(400 / 800, 400 / 600))
+        self.assertEqual(factor_none, min(400 / 800, 400 / 600))
+
     def test_falsey_file_argument(self):
         with self.assertRaises(ValueError):
             self.BACKEND.get_thumbnail('', '100x100')


### PR DESCRIPTION
## Summary
Changed the condition to `return min(factors) if not crop or crop == 'noop' else max(factors)`, matching the reporter's suggested fix and the existing 'noop' handling in crop().

## Problem
jazzband/sorl-thumbnail issue reference: jazzband/sorl-thumbnail#800 (refile of the previously-closed #407, same underlying code unchanged)

## Root Cause
sorl/thumbnail/engines/base.py's _calculate_scaling_factor() did `return max(factors) if crop else min(factors)`. The string 'noop' is truthy in Python, so it took the max() (crop-fitting) branch like any real crop value instead of the min() (fit-within-bounds) branch used for no-crop. Note: the sibling crop() method already special-cases `crop == 'noop'` as a no-op (line 96: `if not crop or crop == 'noop': return image`), so this fix brings _calculate_scaling_factor() into line with the rest of the crop pipeline rather than introducing a new, uncoordinated special case.

## Testing
PASS - all 7 tests ran OK (new regression test plus related SimpleTestCase/CropTestCase tests to confirm no regression in real crop behavior).

## Related Issue
jazzband/sorl-thumbnail#800 (refile of the previously-closed #407, same underlying code unchanged)
