### PR TITLE
fix: MD5 usage so thumbnails work on hosts with FIPS enabled

### DIFF
--- a/sorl/thumbnail/helpers.py
+++ b/sorl/thumbnail/helpers.py
@@ -41,7 +41,7 @@ def tokey(*args):
     Computes a unique key from arguments given.
     """
     salt = '||'.join([force_str(arg) for arg in args])
-    return hashlib.md5(salt.encode()).hexdigest()
+    return hashlib.md5(salt.encode(), usedforsecurity=False).hexdigest()
 
 
 def serialize(obj):


### PR DESCRIPTION
On a host with FIPS enabled, OpenSSL errors when provided with an MD5 without the caller declaring that the digest is "not being used for security."

`tokey()` just creates a thumbnail cache key rather than something security related so here I am just adding `usedforsecurity=False` nothing else changes.